### PR TITLE
Prepare for API/Integration Tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,7 @@ dependencies = [
 name = "kapi"
 version = "0.1.0"
 dependencies = [
+ "bitfield",
  "bytemuck",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,7 @@ name = "kapi"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "log",
  "serde",
  "snafu",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
+name = "api_tests"
+version = "0.1.0"
+dependencies = [
+ "kapi",
+ "log",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["kernel", "init", "kapi"]
+members = ["kernel", "init", "kapi", "api_tests"]
 resolver = "2"

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ $(QEMU):
 all-bindep: $(QEMU) $(UBOOT_BIN)/u-boot.bin $(UBOOT_BIN)/tools/mkimage
 
 # Building/Packaging the Kernel
-build-all: $(BUILD_DIR)/kernel.img $(BUILD_DIR)/init #? Build and package everything.
+build-all: $(BUILD_DIR)/kernel.img $(BUILD_DIR)/init $(BUILD_DIR)/api_tests #? Build and package everything.
 
 build-rust: #? Build all Rust source.
 	export CC_aarch64_unknown_none=aarch64-linux-gnu-gcc
@@ -39,6 +39,10 @@ $(BUILD_DIR)/init: build-rust $(TARGET_DIR)/init
 	mkdir -p $(BUILD_DIR)
 	cp $(TARGET_DIR)/init $(BUILD_DIR)/init
 
+$(BUILD_DIR)/api_tests: build-rust $(TARGET_DIR)/api_tests
+	mkdir -p $(BUILD_DIR)
+	cp $(TARGET_DIR)/api_tests $(BUILD_DIR)/api_tests
+
 
 # QEMU Run/Test/Debug
 run: build-all $(QEMU) $(UBOOT_BIN)/u-boot.bin #? Boots the system inside QEMU.
@@ -51,6 +55,8 @@ test: build-all $(QEMU) $(UBOOT_BIN)/u-boot.bin $(UBOOT_BIN)/tools/mkimage #? Ru
 	mkdir -p $(BUILD_DIR)
 	cargo test -p kernel
 
+api-test: build-all $(QEMU) $(UBOOT_BIN)/u-boot.bin #? Boots system inside QEMU and runs API tests.
+	./scripts/qemu-exec.sh $(BUILD_DIR) '{"init_process_path":"/fat/api_tests"}'
 
 # Rule to extract documentation comments for each rule in the Makefile
 # Comments are `#?` after the rule head.

--- a/api_tests/Cargo.toml
+++ b/api_tests/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "api_tests"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+log = "0.4"
+kapi = { path = "../kapi" }

--- a/api_tests/src/main.rs
+++ b/api_tests/src/main.rs
@@ -13,7 +13,7 @@ use core::ptr::NonNull;
 
 use kapi::{
     queue::{Queue, FIRST_RECV_QUEUE_ID, FIRST_SEND_QUEUE_ID},
-    system_calls::{exit, KernelLogger},
+    system_calls::{exit, yield_now, KernelLogger},
     Command, Completion, SuccessCode,
 };
 
@@ -58,6 +58,7 @@ fn cmd_test(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
             assert_eq!(c.result1, 42);
             return;
         }
+        yield_now();
     }
 }
 

--- a/api_tests/src/main.rs
+++ b/api_tests/src/main.rs
@@ -88,11 +88,11 @@ pub extern "C" fn _start(
 
     test_runner(&[&cmd_test], &send_qu, &recv_qu);
 
-    exit();
+    exit(0);
 }
 
 #[panic_handler]
 pub fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     log::error!("panic! {info}");
-    exit()
+    exit(1)
 }

--- a/init/src/main.rs
+++ b/init/src/main.rs
@@ -90,6 +90,5 @@ pub extern "C" fn _start(
 #[panic_handler]
 pub fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     log::error!("panic! {info}");
-    exit();
-    loop {}
+    exit()
 }

--- a/init/src/main.rs
+++ b/init/src/main.rs
@@ -58,11 +58,11 @@ pub extern "C" fn _start(
         }
     }
 
-    exit()
+    exit(0)
 }
 
 #[panic_handler]
 pub fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     log::error!("panic! {info}");
-    exit()
+    exit(1)
 }

--- a/init/src/main.rs
+++ b/init/src/main.rs
@@ -45,7 +45,6 @@ pub extern "C" fn _start(
         .post(&Command {
             kind: kapi::CommandKind::Test,
             id: 0,
-            completion_semaphore: None,
             args: [1, 2, 3, 4],
         })
         .expect("post message to channel");
@@ -59,32 +58,7 @@ pub extern "C" fn _start(
         }
     }
 
-    exit();
-
-    // let sus_addr = 0x5000 as *mut u8;
-    // let x = unsafe { sus_addr.read_volatile() };
-    // log::info!("got {x}");
-
-    // let path = "/fat/abcdefghij/test.txt";
-    let path = "/fat/init";
-    log::info!("spawning process {path}");
-    send_qu
-        .post(&Command {
-            kind: kapi::CommandKind::SpawnProcess,
-            id: 1,
-            completion_semaphore: None,
-            args: [path.as_ptr() as u64, path.len() as u64, 0, 0],
-        })
-        .expect("post message to channel");
-
-    loop {
-        if let Some(c) = recv_qu.poll() {
-            log::info!("got kernel response: {c:?}");
-            break;
-        }
-    }
-
-    exit();
+    exit()
 }
 
 #[panic_handler]

--- a/kapi/Cargo.toml
+++ b/kapi/Cargo.toml
@@ -10,6 +10,4 @@ serde = { version = "1.0", features = ["derive"], default-features = false }
 snafu = { version = "0.8", default-features = false, features = ["unstable-core-error", "rust_1_65"] }
 log = "0.4"
 bytemuck = "1"
-
-[features]
-kernel = []
+bitfield = "0.14"

--- a/kapi/Cargo.toml
+++ b/kapi/Cargo.toml
@@ -8,4 +8,8 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0", features = ["derive"], default-features = false }
 snafu = { version = "0.8", default-features = false, features = ["unstable-core-error", "rust_1_65"] }
+log = "0.4"
 bytemuck = "1"
+
+[features]
+kernel = []

--- a/kapi/src/lib.rs
+++ b/kapi/src/lib.rs
@@ -1,3 +1,4 @@
+//! API definitions and helpers for interacting with the kernel from user space.
 #![no_std]
 #![feature(non_null_convenience)]
 

--- a/kapi/src/lib.rs
+++ b/kapi/src/lib.rs
@@ -2,7 +2,8 @@
 #![no_std]
 #![feature(non_null_convenience)]
 
-use core::num::NonZeroU32;
+use bitfield::bitfield;
+use bytemuck::Contiguous;
 
 pub mod queue;
 pub mod system_calls;
@@ -21,23 +22,92 @@ pub enum CommandKind {
 pub struct Command {
     pub kind: CommandKind,
     pub id: u16,
-    pub completion_semaphore: Option<NonZeroU32>,
     pub args: [u64; 4],
 }
 
 #[repr(u16)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum CompletionKind {
-    Invalid = 0,
-    Success,
+pub enum SuccessCode {
+    Success = 0,
+}
+
+unsafe impl Contiguous for SuccessCode {
+    type Int = u16;
+
+    const MAX_VALUE: Self::Int = 0;
+
+    const MIN_VALUE: Self::Int = 0;
+}
+
+#[repr(u16)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ErrorCode {
+    InvalidStatusCode = 0,
     UnknownCommand,
-    Error,
+}
+
+unsafe impl Contiguous for ErrorCode {
+    type Int = u16;
+
+    const MAX_VALUE: Self::Int = 1;
+
+    const MIN_VALUE: Self::Int = 0;
+}
+
+bitfield! {
+    #[derive(Default, Clone, Copy, Eq, PartialEq)]
+    pub struct CompletionStatus(u16);
+    impl Debug;
+    bool, is_error, set_error: 15;
+    u16, code, set_code: 14, 0;
+}
+
+impl CompletionStatus {
+    pub fn error_code(&self) -> Option<ErrorCode> {
+        self.is_error()
+            .then(|| self.code())
+            .and_then(ErrorCode::from_integer)
+    }
+
+    pub fn success_code(&self) -> Option<SuccessCode> {
+        (!self.is_error())
+            .then(|| self.code())
+            .and_then(SuccessCode::from_integer)
+    }
+
+    pub fn into_result(self) -> Result<SuccessCode, ErrorCode> {
+        if self.is_error() {
+            Err(ErrorCode::from_integer(self.code()).unwrap_or(ErrorCode::InvalidStatusCode))
+        } else if let Some(s) = SuccessCode::from_integer(self.code()) {
+            Ok(s)
+        } else {
+            Err(ErrorCode::InvalidStatusCode)
+        }
+    }
+}
+
+impl From<SuccessCode> for CompletionStatus {
+    fn from(value: SuccessCode) -> Self {
+        let mut s = CompletionStatus::default();
+        s.set_error(false);
+        s.set_code(value.into_integer());
+        s
+    }
+}
+
+impl From<ErrorCode> for CompletionStatus {
+    fn from(value: ErrorCode) -> Self {
+        let mut s = CompletionStatus::default();
+        s.set_error(true);
+        s.set_code(value.into_integer());
+        s
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Completion {
-    pub kind: CompletionKind,
+    pub status: CompletionStatus,
     pub response_to_id: u16,
     pub result0: u32,
     pub result1: u64,

--- a/kapi/src/queue.rs
+++ b/kapi/src/queue.rs
@@ -1,15 +1,21 @@
+//! Asynchronous queues for kernel/user-space communication.
 use core::{num::NonZeroU16, ptr::NonNull, sync::atomic::AtomicUsize};
 
 use snafu::Snafu;
 
+/// Errors that could occur interacting with a queue.
 #[derive(Debug, Snafu)]
 pub enum Error {
+    /// The queue is full.
     #[snafu(display("queue is too full to receive message"))]
     Full,
 }
 
+/// An ID that uniquely identifies a queue relative to the process it is in.
 pub type QueueId = NonZeroU16;
+/// The ID of the first send queue (created by the kernel) for each process.
 pub const FIRST_SEND_QUEUE_ID: QueueId = unsafe { NonZeroU16::new_unchecked(1) };
+/// The ID of the first receve queue (created by the kernel) for each process.
 pub const FIRST_RECV_QUEUE_ID: QueueId = unsafe { NonZeroU16::new_unchecked(2) };
 
 /// A single synchronized queue reference.
@@ -19,6 +25,7 @@ pub const FIRST_RECV_QUEUE_ID: QueueId = unsafe { NonZeroU16::new_unchecked(2) }
 ///
 /// A queue is internally mutable and synchronized.
 pub struct Queue<T> {
+    /// The process-unique ID of this queue.
     pub id: QueueId,
     queue_len: usize,
     /// A pointer into the buffer to the value of the head index.

--- a/kapi/src/system_calls.rs
+++ b/kapi/src/system_calls.rs
@@ -15,8 +15,9 @@ mod wrappers {
 
     /// Exit the current process.
     #[inline]
-    pub fn exit() {
+    pub fn exit() -> ! {
         unsafe { asm!("svc #1") }
+        unreachable!()
     }
 
     /// Write a log record into the system log.

--- a/kapi/src/system_calls.rs
+++ b/kapi/src/system_calls.rs
@@ -1,3 +1,6 @@
+//! Definitions for synchronous system calls.
+
+/// The numeric symbol given to identify each system call.
 #[repr(u16)]
 pub enum SystemCallNumber {
     Exit = 1,
@@ -5,3 +8,44 @@ pub enum SystemCallNumber {
     Yield = 10,
     WaitForMessage = 11,
 }
+
+#[cfg(not(features = "kernel"))]
+mod wrappers {
+    use core::arch::asm;
+
+    /// Exit the current process.
+    #[inline]
+    pub fn exit() {
+        unsafe { asm!("svc #1") }
+    }
+
+    /// Write a log record into the system log.
+    #[inline]
+    pub fn log_record(r: &log::Record) {
+        unsafe {
+            asm!(
+                "mov x0, {p}",
+                "svc #4",
+                p = in(reg) r as *const log::Record
+            )
+        }
+    }
+
+    /// A [log::Log] implementation that writes log records into the system log.
+    pub struct KernelLogger;
+
+    impl log::Log for KernelLogger {
+        fn enabled(&self, _metadata: &log::Metadata) -> bool {
+            true
+        }
+
+        fn log(&self, record: &log::Record) {
+            log_record(record);
+        }
+
+        fn flush(&self) {}
+    }
+}
+
+#[cfg(not(features = "kernel"))]
+pub use wrappers::*;

--- a/kapi/src/system_calls.rs
+++ b/kapi/src/system_calls.rs
@@ -23,6 +23,12 @@ pub fn exit(code: u32) -> ! {
     unreachable!()
 }
 
+/// Yield execution, causing a new thread to be scheduled.
+#[inline]
+pub fn yield_now() {
+    unsafe { asm!("svc #10",) }
+}
+
 /// Write a log record into the system log.
 #[inline]
 pub fn log_record(r: &log::Record) {

--- a/kapi/src/system_calls.rs
+++ b/kapi/src/system_calls.rs
@@ -12,8 +12,14 @@ pub enum SystemCallNumber {
 
 /// Exit the current process.
 #[inline]
-pub fn exit() -> ! {
-    unsafe { asm!("svc #1") }
+pub fn exit(code: u32) -> ! {
+    unsafe {
+        asm!(
+            "mov w0, {p:w}",
+            "svc #1",
+            p = in(reg) code
+        )
+    }
     unreachable!()
 }
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -36,7 +36,7 @@ futures = { version = "0.3", features = ["alloc"], default-features = false }
 qemu-exit = "3.0.1"
 
 # software interface
-kapi = { path = "../kapi", features = ["kernel"] }
+kapi = { path = "../kapi" }
 elf = { version = "0.7.2", default-features = false }
 serde-json-core = "0.5"
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -36,7 +36,7 @@ futures = { version = "0.3", features = ["alloc"], default-features = false }
 qemu-exit = "3.0.1"
 
 # software interface
-kapi = { path = "../kapi" }
+kapi = { path = "../kapi", features = ["kernel"] }
 elf = { version = "0.7.2", default-features = false }
 serde-json-core = "0.5"
 

--- a/kernel/src/init.rs
+++ b/kernel/src/init.rs
@@ -148,7 +148,10 @@ pub async fn finish_boot(opts: BootOptions<'_>) {
 
     log::info!("init pid = {}", init_proc.id);
 
-    let ec = init_proc.exit_code().await;
-
-    log::info!("init process exited with code {ec:?}");
+    let ec = init_proc
+        .exit_code()
+        .await
+        .expect("init process killed unexpectedly");
+    log::warn!("init process exited with code {ec}");
+    qemu_exit::AArch64::new().exit(ec);
 }

--- a/kernel/src/init.rs
+++ b/kernel/src/init.rs
@@ -147,4 +147,8 @@ pub async fn finish_boot(opts: BootOptions<'_>) {
         .expect("spawn init process");
 
     log::info!("init pid = {}", init_proc.id);
+
+    let ec = init_proc.exit_code().await;
+
+    log::info!("init process exited with code {ec:?}");
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -135,7 +135,6 @@ pub fn panic_handler(info: &core::panic::PanicInfo) -> ! {
         base: 0xffff_0000_0900_0000 as *mut u8,
     };
     let _ = uart.write_fmt(format_args!("\npanic! {info}\n"));
-    // TODO: why can't we get this to only happen during cfg(test)?
     qemu_exit::aarch64::AArch64::new().exit_failure();
     // prevent anything from getting scheduled after a kernel panic
     intrinsics::halt();
@@ -162,7 +161,7 @@ where
     }
 }
 
-/// Run provided tests, then exit QEMU or halt.
+/// Run tests as gathered by the test runner.
 pub fn test_runner(tests: &[&dyn Testable]) {
     log::info!("running {} tests...", tests.len());
     for test in tests {
@@ -172,7 +171,7 @@ pub fn test_runner(tests: &[&dyn Testable]) {
 }
 
 #[macro_export]
-/// Assert that some type `t` implements [Send], causing a compiler error if not.
+/// Assert that some type `T` implements [Send], causing a compiler error if not.
 macro_rules! assert_send {
     ($t:ty) => {
         const _: fn() = || {
@@ -184,7 +183,7 @@ macro_rules! assert_send {
 }
 
 #[macro_export]
-/// Assert that some type `t` implements [Sync], causing a compiler error if not.
+/// Assert that some type `T` implements [Sync], causing a compiler error if not.
 macro_rules! assert_sync {
     ($t:ty) => {
         const _: fn() = || {

--- a/kernel/src/process/interface/dispatch_cmd.rs
+++ b/kernel/src/process/interface/dispatch_cmd.rs
@@ -10,7 +10,7 @@ pub async fn dispatch(proc: &Arc<Process>, cmd: Command) -> Completion {
             kind: CompletionKind::Success,
             response_to_id: cmd.id,
             result0: proc.id.into(),
-            result1: 0,
+            result1: cmd.args[0],
         },
         CommandKind::SpawnProcess => {
             let path_bytes = unsafe {

--- a/kernel/src/process/interface/dispatch_cmd.rs
+++ b/kernel/src/process/interface/dispatch_cmd.rs
@@ -4,10 +4,11 @@ use kapi::*;
 // TODO: refactor into a function that returns Result<Completion, Error> and change this function
 // so that it calls that function and then on errors calls some Error -> Completion function
 pub async fn dispatch(proc: &Arc<Process>, cmd: Command) -> Completion {
+    log::debug!("received from pid {}: {cmd:?}", proc.id);
     match cmd.kind {
         CommandKind::Invalid => todo!(),
         CommandKind::Test => Completion {
-            kind: CompletionKind::Success,
+            status: SuccessCode::Success.into(),
             response_to_id: cmd.id,
             result0: proc.id.into(),
             result1: cmd.args[0],
@@ -21,7 +22,7 @@ pub async fn dispatch(proc: &Arc<Process>, cmd: Command) -> Completion {
                 Path::new(core::str::from_utf8(path_bytes).expect("TODO: graceful error handling"));
             match spawn_process(path, None::<fn(_)>).await {
                 Ok(proc) => Completion {
-                    kind: CompletionKind::Success,
+                    status: SuccessCode::Success.into(),
                     response_to_id: cmd.id,
                     result0: proc.id.into(),
                     result1: 0,
@@ -29,17 +30,12 @@ pub async fn dispatch(proc: &Arc<Process>, cmd: Command) -> Completion {
                 Err(e) => {
                     log::error!("process {}: failed to spawn process: {e}", proc.id);
                     // TODO: compute error code
-                    Completion {
-                        kind: CompletionKind::Error,
-                        response_to_id: cmd.id,
-                        result0: 0,
-                        result1: 0,
-                    }
+                    todo!()
                 }
             }
         }
         CommandKind::Reserved(kind) => Completion {
-            kind: CompletionKind::UnknownCommand,
+            status: ErrorCode::UnknownCommand.into(),
             response_to_id: cmd.id,
             result0: kind as u32,
             result1: 0,

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -10,17 +10,19 @@ use crate::{
     },
     tasks::locks::Mutex,
 };
-use alloc::sync::Arc;
+use alloc::{sync::Arc, vec::Vec};
 
-use bitfield::{bitfield, Bit};
+use bitfield::Bit;
 use core::{
-    cell::OnceCell,
     num::NonZeroU32,
     sync::atomic::{AtomicU16, AtomicU32},
+    task::Waker,
 };
+use futures::Future;
 use kapi::{Command, Completion};
 use smallvec::SmallVec;
 use snafu::{OptionExt, ResultExt, Snafu};
+use spin::{Mutex as SpinMutex, Once};
 
 pub mod thread;
 pub use thread::{scheduler::scheduler, threads, Thread, ThreadId};
@@ -47,12 +49,19 @@ pub struct Process {
     threads: Mutex<SmallVec<[Arc<Thread>; 2]>>,
     /// Page tables for this process.
     page_tables: PageTable,
+    /// Allocator for the virtual address space of the process.
     #[allow(dead_code)]
     address_space_allocator: VirtualAddressAllocator,
+    /// The next free queue ID.
     #[allow(dead_code)]
     next_queue_id: AtomicU16,
+    /// The queues associated with this process.
     #[allow(clippy::type_complexity)]
     queues: ConcurrentLinkedList<(Arc<OwnedQueue<Command>>, Arc<OwnedQueue<Completion>>)>,
+    /// The exit code this process exited with (if it has exited).
+    exit_code: Once<Option<u32>>,
+    /// Future wakers for futures waiting on exit code.
+    exit_waker: SpinMutex<Vec<Waker>>,
 }
 
 crate::assert_sync!(Process);
@@ -99,25 +108,55 @@ impl Process {
         // needs to be notified that one of its threads just died. If this is the last thread
         // in the process than the process itself is now dead
     }
+
+    /// Create a future that will resolve with the value of the exit code when this process exits.
+    /// If the process is killed or aborted, then [None] will be returned.
+    pub fn exit_code(self: &Arc<Process>) -> impl Future<Output = Option<u32>> {
+        ProcessExitFuture { proc: self.clone() }
+    }
 }
 
-static mut PROCESSES: OnceCell<ConcurrentLinkedList<Arc<Process>>> = OnceCell::new();
+static PROCESSES: Once<ConcurrentLinkedList<Arc<Process>>> = Once::new();
 
-static mut NEXT_PID: AtomicU32 = AtomicU32::new(1);
+static NEXT_PID: AtomicU32 = AtomicU32::new(1);
 
 /// The global table of processes by ID.
 pub fn processes() -> &'static ConcurrentLinkedList<Arc<Process>> {
-    unsafe { PROCESSES.get_or_init(Default::default) }
+    PROCESSES.call_once(Default::default)
 }
 
 pub fn process_for_id(id: ProcessId) -> Option<Arc<Process>> {
     processes().iter().find(|p| p.id == id).cloned()
 }
 
-/// Cause a process to exit by ID, freeing its resources.
+struct ProcessExitFuture {
+    proc: Arc<Process>,
+}
+
+impl Future for ProcessExitFuture {
+    type Output = Option<u32>;
+
+    fn poll(
+        self: core::pin::Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> core::task::Poll<Self::Output> {
+        match self.proc.exit_code.poll() {
+            Some(c) => core::task::Poll::Ready(*c),
+            None => {
+                self.proc.exit_waker.lock().push(cx.waker().clone());
+                core::task::Poll::Pending
+            }
+        }
+    }
+}
+
+/// Cause a process to exit, freeing its resources.
+///
+/// Because threads have strong references to their parent process, process resources will not be
+/// freed unless this function is called.
 // TODO: this should be somewhere else, perhaps with `spawn`.
-fn exit_process(proc: Arc<Process>) {
-    log::trace!("process {} exited", proc.id);
+fn exit_process(proc: Arc<Process>, exit_code: Option<u32>) {
+    log::trace!("process {} exited with code {exit_code:?}", proc.id);
 
     processes().remove(|p| p.id == proc.id);
 
@@ -129,30 +168,24 @@ fn exit_process(proc: Arc<Process>) {
         // drop thread
     }
 
-    // TODO: move this to drop since it is not async anymore
-    // deal with async resources, and then drop the process (by moving it into the task)
-    crate::tasks::spawn(async move {
-        // free physical memory mapped in process page table
-        for mapped_region in proc.page_tables.iter() {
-            physical_memory_allocator()
-                .free_pages(mapped_region.base_phys_addr, mapped_region.page_count);
-        }
+    proc.exit_code.call_once(|| exit_code);
+    for w in proc.exit_waker.lock().drain(..) {
+        w.wake();
+    }
 
-        // drop process, releasing its resources
-        // TODO: make sure we don't double free the channel
-    });
+    for mapped_region in proc.page_tables.iter() {
+        physical_memory_allocator()
+            .free_pages(mapped_region.base_phys_addr, mapped_region.page_count);
+    }
 }
 
 /// Register system calls related to processes and thread scheduling.
 pub fn register_system_call_handlers() {
     use kapi::system_calls::SystemCallNumber;
     let h = crate::exception::system_call_handlers();
-    h.insert_blocking(
-        SystemCallNumber::Exit as u16,
-        |_id, proc, _thread, _regs| {
-            exit_process(proc);
-        },
-    );
+    h.insert_blocking(SystemCallNumber::Exit as u16, |_id, proc, _thread, regs| {
+        exit_process(proc, Some(regs.x[0] as u32));
+    });
     h.insert_blocking(
         SystemCallNumber::Yield as u16,
         |_id, _proc, _thread, _regs| {

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -69,7 +69,6 @@ impl Process {
         let this = &Arc::downgrade(self);
         for (send_qu, assoc_recv_qu) in self.queues.iter() {
             while let Some(cmd) = send_qu.poll() {
-                log::trace!("recieved command: {cmd:?}");
                 let this = this.clone();
                 let assoc_recv_qu = assoc_recv_qu.clone();
                 crate::tasks::spawn(async move {

--- a/kernel/src/process/spawn.rs
+++ b/kernel/src/process/spawn.rs
@@ -239,7 +239,7 @@ pub async fn spawn_process(
     let queues = ConcurrentLinkedList::default();
     queues.push((Arc::new(send_qu), Arc::new(recv_qu)));
 
-    log::debug!("process page table: {pt:?}");
+    // log::debug!("process page table: {pt:?}");
 
     // create process structure
     let proc = Arc::new(Process {

--- a/kernel/src/process/spawn.rs
+++ b/kernel/src/process/spawn.rs
@@ -1,5 +1,6 @@
 use elf::segment::ProgramHeader;
 use kapi::queue::{FIRST_RECV_QUEUE_ID, FIRST_SEND_QUEUE_ID};
+use spin::once::Once;
 
 use super::*;
 
@@ -249,6 +250,8 @@ pub async fn spawn_process(
         next_queue_id: AtomicU16::new((FIRST_RECV_QUEUE_ID.saturating_add(1)).into()),
         queues,
         address_space_allocator,
+        exit_code: Once::new(),
+        exit_waker: spin::Mutex::new(Vec::new()),
     });
     processes().push(proc.clone());
 

--- a/kernel/src/process/thread/reg.rs
+++ b/kernel/src/process/thread/reg.rs
@@ -1,5 +1,7 @@
 //! Registers related to threads/execution state.
-use super::*;
+use bitfield::bitfield;
+
+use crate::memory::VirtualAddress;
 
 bitfield! {
     /// The value of the SPSR (Saved Program Status) register.

--- a/kernel/src/tasks/mod.rs
+++ b/kernel/src/tasks/mod.rs
@@ -84,7 +84,7 @@ impl Executor {
         loop {
             // log::trace!("top of loop");
             while let Some((task_id, task)) = self.new_task_queue.pop() {
-                log::trace!("adding new task {task_id}");
+                // log::trace!("adding new task {task_id}");
                 tasks.insert(task_id, task);
                 // make sure tasks are only in the ready queue after they have been added to the tasks map
                 self.ready_queue
@@ -103,7 +103,7 @@ impl Executor {
                     .entry(task_id)
                     .or_insert_with(|| TaskWaker::new_waker(task_id, self.ready_queue.clone()));
                 let mut context = Context::from_waker(waker);
-                log::debug!("polling task {task_id}");
+                // log::trace!("polling task {task_id}");
                 match task.as_mut().poll(&mut context) {
                     Poll::Ready(()) => {
                         log::trace!("task {task_id} finished");

--- a/kernel/src/uart.rs
+++ b/kernel/src/uart.rs
@@ -25,6 +25,7 @@ pub struct DebugUartLogger;
 const DISABLED_MODULES: &[&str] = &[
     "kernel::memory::paging",
     "kernel::memory::heap",
+    "kernel::memory::physical_memory_allocator",
     "kernel::process::thread::scheduler",
     "kernel::exception",
 ];


### PR DESCRIPTION
Implement features in kernel necessary to implement API integration tests, and also define the basic structure of these tests.

## TODO
- [x] Exit status for processes
- [x] Future that resolves on process exit
- [x] Wait for `init` process to exit and then exit QEMU with the same status
- [ ] ~~kernel-wide error handling unification~~
