### PR TITLE
Fix Queues, other bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,7 @@ version = "0.1.0"
 dependencies = [
  "bitfield",
  "bytemuck",
+ "crossbeam-utils",
  "log",
  "serde",
  "snafu",

--- a/api_tests/src/main.rs
+++ b/api_tests/src/main.rs
@@ -52,7 +52,7 @@ pub fn test_runner(
 
 fn cmd_invalid(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
     send_qu
-        .post(&Command {
+        .post(Command {
             id: 0,
             kind: CmdKind::Invalid,
         })
@@ -70,7 +70,7 @@ fn cmd_invalid(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
 
 fn cmd_test(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
     send_qu
-        .post(&Command {
+        .post(Command {
             id: 0,
             kind: Test { arg: 42 }.into(),
         })
@@ -98,24 +98,24 @@ mod queues;
 #[no_mangle]
 pub extern "C" fn _start(
     send_qu_addr: usize,
-    send_qu_len: usize,
+    send_qu_cap: usize,
     recv_qu_addr: usize,
-    recv_qu_len: usize,
+    recv_qu_cap: usize,
 ) {
     log::set_logger(&KernelLogger).expect("set logger");
     log::set_max_level(log::LevelFilter::Trace);
-    log::info!("starting API test process. kernel queues @ Send[0x{send_qu_addr:x}:{send_qu_len:x}] Recv[0x{recv_qu_addr:x}:{recv_qu_len:x}]");
+    log::info!("starting API test process. kernel queues @ Send[0x{send_qu_addr:x}:{send_qu_cap:x}] Recv[0x{recv_qu_addr:x}:{recv_qu_cap:x}]");
     let (send_qu, recv_qu) = unsafe {
         (
             Queue::new(
                 FIRST_SEND_QUEUE_ID,
-                send_qu_len,
                 NonNull::new(send_qu_addr as *mut _).expect("send queue ptr is non-null"),
+                send_qu_cap,
             ),
             Queue::<Completion>::new(
                 FIRST_RECV_QUEUE_ID,
-                recv_qu_len,
                 NonNull::new(recv_qu_addr as *mut _).expect("recv queue ptr is non-null"),
+                recv_qu_cap,
             ),
         )
     };

--- a/api_tests/src/queues.rs
+++ b/api_tests/src/queues.rs
@@ -16,7 +16,7 @@ pub const TESTS: &[&dyn Testable] = &[
 fn basic_create_destroy(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
     // create a completion queue
     send_qu
-        .post(&Command {
+        .post(Command {
             id: 0,
             kind: CreateCompletionQueue { size: 16 }.into(),
         })
@@ -40,7 +40,7 @@ fn basic_create_destroy(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
 
     // create a submission queue and associate it with our completion queue
     send_qu
-        .post(&Command {
+        .post(Command {
             id: 1,
             kind: CreateSubmissionQueue {
                 size: 16,
@@ -69,17 +69,15 @@ fn basic_create_destroy(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
     // try sending a test command on the new queues
     crate::cmd_test(&sub_qu, &cmpl_qu);
 
-    log::trace!("e: {}", send_qu.is_empty());
-
     // destroy both queues
     send_qu
-        .post(&Command {
+        .post(Command {
             id: 2,
             kind: DestroyQueue { id: sub_qu.id }.into(),
         })
         .expect("post destroy subm queue msg");
     send_qu
-        .post(&Command {
+        .post(Command {
             id: 3,
             kind: DestroyQueue { id: cmpl_qu.id }.into(),
         })
@@ -107,7 +105,7 @@ fn fail_to_create_submission_queue_with_bad_completion_id(
 ) {
     // create a submission queue and try to associate it with an invalid completion queue ID
     send_qu
-        .post(&Command {
+        .post(Command {
             id: 1,
             kind: CreateSubmissionQueue {
                 size: 16,
@@ -133,7 +131,7 @@ fn fail_to_create_submission_queue_with_bad_completion_id(
 fn fail_to_create_queue_with_zero_size(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
     // create a submission queue and try to associate it with an invalid completion queue ID
     send_qu
-        .post(&Command {
+        .post(Command {
             id: 1,
             kind: CreateCompletionQueue { size: 0 }.into(),
         })

--- a/init/src/main.rs
+++ b/init/src/main.rs
@@ -20,24 +20,24 @@ use kapi::{
 #[no_mangle]
 pub extern "C" fn _start(
     send_qu_addr: usize,
-    send_qu_len: usize,
+    send_qu_cap: usize,
     recv_qu_addr: usize,
-    recv_qu_len: usize,
+    recv_qu_cap: usize,
 ) {
     log::set_logger(&KernelLogger).expect("set logger");
     log::set_max_level(log::LevelFilter::Trace);
-    log::info!("starting init process. kernel queues @ Send[0x{send_qu_addr:x}:{send_qu_len:x}] Recv[0x{recv_qu_addr:x}:{recv_qu_len:x}]");
+    log::info!("starting init process. kernel queues @ Send[0x{send_qu_addr:x}:{send_qu_cap:x}] Recv[0x{recv_qu_addr:x}:{recv_qu_cap:x}]");
     let (send_qu, recv_qu) = unsafe {
         (
             Queue::new(
                 FIRST_SEND_QUEUE_ID,
-                send_qu_len,
                 NonNull::new(send_qu_addr as *mut _).expect("send queue ptr is non-null"),
+                send_qu_cap,
             ),
             Queue::<Completion>::new(
                 FIRST_RECV_QUEUE_ID,
-                recv_qu_len,
                 NonNull::new(recv_qu_addr as *mut _).expect("recv queue ptr is non-null"),
+                recv_qu_cap,
             ),
         )
     };

--- a/kapi/Cargo.toml
+++ b/kapi/Cargo.toml
@@ -11,3 +11,4 @@ snafu = { version = "0.8", default-features = false, features = ["unstable-core-
 log = "0.4"
 bytemuck = "1"
 bitfield = "0.14"
+crossbeam-utils = { version = "0.8", default-features = false }

--- a/kapi/src/completions.rs
+++ b/kapi/src/completions.rs
@@ -44,6 +44,9 @@ pub enum ErrorCode {
     /// A size was provided that is invalid for the operation.
     InvalidSize,
 
+    /// The object was still in use when its destruction was requested.
+    InUse,
+
     /// An internal kernel error occurred, check the system log for details.
     Internal,
 }
@@ -51,6 +54,15 @@ pub enum ErrorCode {
 impl From<ErrorCode> for Kind {
     fn from(value: ErrorCode) -> Self {
         Kind::Err(value)
+    }
+}
+
+/// Response to a command with no returned values, but indicates success.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Success;
+impl From<Success> for Kind {
+    fn from(_value: Success) -> Self {
+        Kind::Success
     }
 }
 

--- a/kapi/src/queue.rs
+++ b/kapi/src/queue.rs
@@ -109,6 +109,12 @@ impl<T> Queue<T> {
     }
 
     /// Initialize the queue. This will remove but not drop anything already in the queue.
+    /// This function exists for the use of the kernel, but is unnecessary for user-space
+    /// processes.
+    ///
+    /// # Safety
+    /// This is only safe to run once after a queue has been allocated but before it is used.
+    /// The queue will not function correctly, however, if it is never called.
     pub unsafe fn initialize(&self) {
         let counters = self.counter_ptr.as_ref();
         counters.head.store(0, Ordering::Relaxed);

--- a/kernel/src/init.rs
+++ b/kernel/src/init.rs
@@ -19,6 +19,7 @@ fn default_init_process_path() -> &'static str {
 /// The kernel deserializes this struct from JSON as found in the bootargs device tree parameter.
 /// Use `env set bootargs ...` to set these in u-boot before booting the kernel.
 #[derive(serde::Deserialize, Debug, Default)]
+#[serde(deny_unknown_fields)]
 pub struct BootOptions<'a> {
     #[serde(default = "default_init_process_path")]
     init_process_path: &'a str,

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -86,7 +86,7 @@ impl Process {
                     if let Some(proc) = this.upgrade() {
                         let cmpl = interface::dispatch(&proc, cmd).await;
                         log::trace!("[pid {}, RQ {}]: {cmpl:?}", proc.id, assoc_recv_qu.id);
-                        match assoc_recv_qu.post(&cmpl) {
+                        match assoc_recv_qu.post(cmpl) {
                             Ok(()) => {}
                             Err(_) => {
                                 todo!("kill process on queue overflow")

--- a/kernel/src/process/spawn.rs
+++ b/kernel/src/process/spawn.rs
@@ -108,7 +108,12 @@ pub fn attach_queues(
         .context(error::MemorySnafu {
             reason: "map process recv queue",
         })?;
-    Ok((send_base_addr, send_qu.len(), recv_base_addr, recv_qu.len()))
+    Ok((
+        send_base_addr,
+        send_qu.capacity(),
+        recv_base_addr,
+        recv_qu.capacity(),
+    ))
 }
 
 /// Creates a new process from a binary loaded from a path in the registry.

--- a/kernel/src/storage/nvme/block_store.rs
+++ b/kernel/src/storage/nvme/block_store.rs
@@ -29,7 +29,6 @@ impl BlockStore for NamespaceBlockStore {
         source_addr: BlockAddress,
         destination_addrs: &'a [(PhysicalAddress, usize)],
     ) -> Result<usize, StorageError> {
-        // log::trace!("read blocks {source_addr}[..{num_blocks}] -> {destination_addrs:?}");
         let total_num_blocks: u16 = destination_addrs
             .iter()
             .map(|(_, n)| n)
@@ -42,6 +41,7 @@ impl BlockStore for NamespaceBlockStore {
                 }
                 .build()
             })?;
+        log::trace!("read blocks {source_addr}[..{total_num_blocks}] -> {destination_addrs:?}");
         let cmp = self.io_cq.wait_for_completion(
             self.io_sq.begin()
                 .expect("NVMe submission queue full. TODO: we should be able to await for a new spot in the queue rather than panic")

--- a/kernel/src/storage/nvme/command.rs
+++ b/kernel/src/storage/nvme/command.rs
@@ -18,6 +18,7 @@ pub enum QueuePriority {
     Low = 0b11,
 }
 
+// TODO: get rid of magic constants and manual bitfields
 #[allow(unused)]
 impl<'sq> Command<'sq> {
     // Admin commands //
@@ -35,7 +36,8 @@ impl<'sq> Command<'sq> {
         physically_continuous: bool,
     ) -> Self {
         self.set_opcode(0x05)
-            .set_dword(10, ((queue_size as u32) << 16) | (queue_id as u32))
+            // queue_size is zeros based (see NVMe Spec§1.5), so the actual value is +1 the given value.
+            .set_dword(10, (((queue_size - 1) as u32) << 16) | (queue_id as u32))
             .set_dword(
                 11,
                 ((interrupt_vector_index as u32) << 16)
@@ -57,7 +59,8 @@ impl<'sq> Command<'sq> {
         physically_continuous: bool,
     ) -> Self {
         self.set_opcode(0x01)
-            .set_dword(10, ((queue_size as u32) << 16) | (queue_id as u32))
+            // queue_size is zeros based (see NVMe Spec§1.5), so the actual value is +1 the given value.
+            .set_dword(10, (((queue_size - 1) as u32) << 16) | (queue_id as u32))
             .set_dword(
                 11,
                 ((completion_queue_id as u32) << 16)

--- a/kernel/src/storage/nvme/interrupt.rs
+++ b/kernel/src/storage/nvme/interrupt.rs
@@ -90,13 +90,13 @@ fn handle_interrupt(
     pending_completions: &Arc<CHashMap<u16, PendingCompletion>>,
 ) {
     use PendingCompletion::*;
-    log::debug!("handling NVMe interrupt {int_id}, {}", qu.queue_id());
+    // log::trace!("handling NVMe interrupt {int_id}, {}", qu.queue_id());
     if let Some(cmp) = qu.pop() {
-        log::debug!(
-            "pc addr: 0x{:x}",
-            Arc::as_ptr(pending_completions) as *const _ as usize
-        );
-        // log::debug!("got completion {cmp:x?}");
+        // log::debug!(
+        //     "pc addr: 0x{:x}",
+        //     Arc::as_ptr(pending_completions) as *const _ as usize
+        // );
+        // log::trace!("completion {cmp:x?}");
         if let Some(mut pc) = pending_completions.get_mut_blocking(&cmp.id) {
             // log::debug!("pending completion?");
             *pc = match &*pc {
@@ -108,7 +108,7 @@ fn handle_interrupt(
                 Ready(old_cmp) => panic!("recieved second completion {cmp:?} for id with pending ready completion {old_cmp:?}"),
             }
         } else {
-            // log::debug!("inserting pending ready completion");
+            // log::trace!("inserting ready completion before future was ever polled");
             pending_completions.insert_blocking(cmp.id, Ready(cmp));
         }
     } else {

--- a/scripts/qemu-exec.sh
+++ b/scripts/qemu-exec.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
+
+boot_dir="$1"
+boot_args="$2"
+
+# make $@ everything after $2
+shift 2
+
 ./qemu/.build/qemu-system-aarch64 -machine virt -cpu cortex-a57 -nographic \
     -bios ./u-boot/.build/u-boot.bin -semihosting \
-    -drive if=none,file=fat:rw:$1,id=kboot,format=raw \
-    -device nvme,drive=kboot,serial=foo $3 \
+    -drive if=none,file=fat:rw:$boot_dir,id=kboot,format=raw \
+    -device nvme,drive=kboot,serial=foo "$@" \
 <<-END
     nvme scan
     fatload nvme 0 0x41000000 kernel.img
-    env set bootargs '$2'
+    env set bootargs '$boot_args'
     bootm 41000000 - 40000000
 END
 


### PR DESCRIPTION
- switch to crossbeam queue implementation
- fix bug in NVMe queues (this prevented the init process from loading and thus warrants a quick merge)
- implement queue destroy so that API tests pass. 

Makes progress on #7: destroy queue API.