### PR TITLE
Implement Basic Process APIs

### DIFF
--- a/kapi/src/completions.rs
+++ b/kapi/src/completions.rs
@@ -109,6 +109,15 @@ pub enum ThreadExit {
 }
 impl_into_kind!(ThreadExit);
 
+/// Response to a [crate::commands::SpawnProcess] command.
+#[repr(C)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewProcess {
+    /// The ID of the new process.
+    pub id: ProcessId,
+}
+impl_into_kind!(NewProcess);
+
 /// Type of completion and any resulting values returned by the command.
 #[repr(u16)]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -123,6 +132,7 @@ pub enum Kind {
     NewQueue(NewQueue),
     NewThread(NewThread),
     ThreadExit(ThreadExit),
+    NewProcess(NewProcess),
     /// The command failed to complete successfully.
     Err(ErrorCode),
 }

--- a/kernel/src/process/spawn.rs
+++ b/kernel/src/process/spawn.rs
@@ -201,7 +201,7 @@ pub async fn spawn_process(
         },
     )
     .context(error::MemorySnafu {
-        reason: "map proces stack",
+        reason: "map process stack",
     })?;
     address_space_allocator
         .reserve(stack_vaddr, stack_page_count)

--- a/kernel/src/registry/mod.rs
+++ b/kernel/src/registry/mod.rs
@@ -61,7 +61,7 @@ impl Node {
         name: &str,
         handler: Box<dyn RegistryHandler>,
     ) -> Result<(), RegistryError> {
-        log::trace!("{}.{name}", prefix.as_path());
+        // log::trace!("{}.{name}", prefix.as_path());
         use Node::*;
         match (prefix.next(), self) {
             (Some(Component::Name(s)), Directory(children)) => children

--- a/ref/REF.md
+++ b/ref/REF.md
@@ -6,6 +6,7 @@
 - [ARMv8 Programming Guide](https://developer.arm.com/documentation/den0024)
 - [GIC Architecture Specification](https://developer.arm.com/documentation/ihi0069/)
 - [Devicetree Specification](https://github.com/devicetree-org/devicetree-specification)
+- [Linux ARM64 Boot Specification](https://www.kernel.org/doc/Documentation/arm64/booting.txt)
 
 ## Devices
 


### PR DESCRIPTION
- [x] Define commands  and system calls
- Write tests for
    - [ ] Spawn
    - [ ] Kill
    - [ ] Heap allocate/free
- Implement
    - [ ] Spawn
    - [ ] Kill
    - [ ] Heap allocate/free
- [ ] a little light refactoring for `spawn_process`

Makes progress on #7: implements the user-space process API.