### PR TITLE
Heap Panic Bug Fix

### DIFF
--- a/api_tests/src/main.rs
+++ b/api_tests/src/main.rs
@@ -7,7 +7,6 @@
 #![feature(allocator_api)]
 #![feature(custom_test_frameworks)]
 #![feature(iter_array_chunks)]
-#![feature(non_null_convenience)]
 
 use core::ptr::NonNull;
 

--- a/init/src/main.rs
+++ b/init/src/main.rs
@@ -6,7 +6,6 @@
 #![feature(allocator_api)]
 #![feature(custom_test_frameworks)]
 #![feature(iter_array_chunks)]
-#![feature(non_null_convenience)]
 
 use core::ptr::NonNull;
 

--- a/kapi/src/lib.rs
+++ b/kapi/src/lib.rs
@@ -1,6 +1,5 @@
 //! API definitions and helpers for interacting with the kernel from user space.
 #![no_std]
-#![feature(non_null_convenience)]
 #![deny(missing_docs)]
 
 use core::num::NonZeroU32;

--- a/kernel/src/exception/handlers.rs
+++ b/kernel/src/exception/handlers.rs
@@ -36,7 +36,7 @@ fn handle_system_call(proc: Arc<Process>, thread: Arc<Thread>, regs: &mut Regist
 #[no_mangle]
 unsafe extern "C" fn handle_synchronous_exception(regs: *mut Registers, esr: usize, far: usize) {
     let esr = ExceptionSyndromeRegister(esr as u64);
-    let ec = ExceptionClass(esr.ec());
+    let ec = esr.ec();
 
     if !ec.is_system_call()
         && !ec.is_user_space_data_page_fault()

--- a/kernel/src/exception/mod.rs
+++ b/kernel/src/exception/mod.rs
@@ -351,6 +351,54 @@ impl core::fmt::Debug for ExceptionClass {
     }
 }
 
+fn dfsc_description(code: u8) -> &'static str {
+    match code {
+        0b000000 => "Address size fault, level 0 of translation or translation table base register",
+        0b000001 => "Address size fault, level 1",
+        0b000010 => "Address size fault, level 2",
+        0b000011 => "Address size fault, level 3",
+        0b000100 => "Translation fault, level 0",
+        0b000101 => "Translation fault, level 1",
+        0b000110 => "Translation fault, level 2",
+        0b000111 => "Translation fault, level 3",
+        0b001000 => "Access flag fault, level 0",
+        0b001001 => "Access flag fault, level 1",
+        0b001010 => "Access flag fault, level 2",
+        0b001011 => "Access flag fault, level 3",
+        0b001100 => "Permission fault, level 0",
+        0b001101 => "Permission fault, level 1",
+        0b001110 => "Permission fault, level 2",
+        0b001111 => "Permission fault, level 3",
+        0b010000 => "Synchronous External abort, not on translation table walk or hardware update of translation table",
+        0b010001 => "Synchronous Tag Check Fault",
+        0b010011 => "Synchronous External abort on translation table walk or hardware update of translation table, level -1",
+        0b010100 => "Synchronous External abort on translation table walk or hardware update of translation table, level 0",
+        0b010101 => "Synchronous External abort on translation table walk or hardware update of translation table, level 1",
+        0b010110 => "Synchronous External abort on translation table walk or hardware update of translation table, level 2",
+        0b010111 => "Synchronous External abort on translation table walk or hardware update of translation table, level 3",
+        0b011000 => "Synchronous parity or ECC error on memory access, not on translation table walk",
+        0b011011 => "Synchronous parity or ECC error on memory access on translation table walk or hardware update of translation table, level -1",
+        0b011100 => "Synchronous parity or ECC error on memory access on translation table walk or hardware update of translation table, level 0",
+        0b011101 => "Synchronous parity or ECC error on memory access on translation table walk or hardware update of translation table, level 1",
+        0b011110 => "Synchronous parity or ECC error on memory access on translation table walk or hardware update of translation table, level 2",
+        0b011111 => "Synchronous parity or ECC error on memory access on translation table walk or hardware update of translation table, level 3",
+        0b100001 => "Alignment fault",
+        0b100011 => "Granule Protection Fault on translation table walk or hardware update of translation table, level -1",
+        0b100100 => "Granule Protection Fault on translation table walk or hardware update of translation table, level 0",
+        0b100101 => "Granule Protection Fault on translation table walk or hardware update of translation table, level 1",
+        0b100110 => "Granule Protection Fault on translation table walk or hardware update of translation table, level 2",
+        0b100111 => "Granule Protection Fault on translation table walk or hardware update of translation table, level 3",
+        0b101000 => "Granule Protection Fault, not on translation table walk or hardware update of translation table",
+        0b101001 => "Address size fault, level -1",
+        0b101011 => "Translation fault, level -1",
+        0b110000 => "TLB conflict abort",
+        0b110001 => "Unsupported atomic hardware update fault",
+        0b110100 => "IMPLEMENTATION DEFINED fault (Lockdown)",
+        0b110101 => "IMPLEMENTATION DEFINED fault (Unsupported Exclusive or Atomic access)",
+        _ => "?",
+    }
+}
+
 impl Display for ExceptionSyndromeRegister {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ESR")
@@ -359,7 +407,16 @@ impl Display for ExceptionSyndromeRegister {
             .field("IL", &self.il())
             .field(
                 "ISS",
-                &format_args!("0x{:x}=0b{:b}", self.iss(), self.iss()),
+                &format_args!(
+                    "0x{:x}=0b{:b} \"{}\"",
+                    self.iss(),
+                    self.iss(),
+                    if self.ec() == 0b10_0101 {
+                        dfsc_description((self.iss() & 0b11_1111) as u8)
+                    } else {
+                        ""
+                    }
+                ),
             )
             .finish()
     }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -13,7 +13,6 @@
 #![feature(linked_list_cursors)]
 #![feature(custom_test_frameworks)]
 #![feature(iter_array_chunks)]
-#![feature(non_null_convenience)]
 #![feature(error_in_core)]
 #![feature(str_from_raw_parts)]
 #![test_runner(crate::test_runner)]


### PR DESCRIPTION
Fixes heap panic due to a free block being incorrectly aligned to store pointers (ie the free block next/prev pointers).
Also adds human readable data abort error messages for debugging in the future.