### PR TITLE
Implement Basic File System API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 target/**
 ref/*.pdf
 
+.aider*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
 name = "elf"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +310,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "kapi"
 version = "0.1.0"
 dependencies = [
@@ -331,6 +346,7 @@ dependencies = [
  "elf",
  "futures",
  "hashbrown",
+ "itertools",
  "kapi",
  "lock_api",
  "log",

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,10 @@ $(BUILD_DIR)/bin/init: build-rust $(TARGET_DIR)/init
 	mkdir -p $(BUILD_DIR)/bin
 	cp $(TARGET_DIR)/init $(BUILD_DIR)/bin/init
 
-$(BUILD_DIR)/bin/api_tests: build-rust $(TARGET_DIR)/api_tests
+$(BUILD_DIR)/test-data-file:
+	printf "%.1s" {1..64} > $(BUILD_DIR)/test-data-file
+
+$(BUILD_DIR)/bin/api_tests: build-rust $(TARGET_DIR)/api_tests $(BUILD_DIR)/test-data-file
 	mkdir -p $(BUILD_DIR)/bin
 	cp $(TARGET_DIR)/api_tests $(BUILD_DIR)/bin/api_tests
 

--- a/api_tests/src/files.rs
+++ b/api_tests/src/files.rs
@@ -23,6 +23,7 @@ pub const TESTS: &[&dyn Testable] = &[
     &open_read_close_created_file,
     &open_read_past_end_close_created_file,
     &open_write_past_end_close_created_file,
+    &resize_truncate_created_file,
     &delete_created_file,
     &fail_to_delete_non_existing,
     &fail_to_read_bad_handle,

--- a/api_tests/src/files.rs
+++ b/api_tests/src/files.rs
@@ -25,6 +25,7 @@ pub const TESTS: &[&dyn Testable] = &[
     &open_write_past_end_close_created_file,
     &resize_truncate_created_file,
     &delete_created_file,
+    &resize_append_created_file,
     &fail_to_delete_non_existing,
     &fail_to_read_bad_handle,
     &fail_to_write_bad_handle,
@@ -501,7 +502,105 @@ fn resize_truncate_created_file(send_qu: &Queue<Command>, recv_qu: &Queue<Comple
     wait_for_success(recv_qu, 3);
 }
 
-fn delete_created_file(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
+fn resize_append_created_file(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
+    let new_size = CREATED_TEST_DATA.len() * 2;
+
+    send_qu
+        .post(Command {
+            id: 0,
+            kind: OpenFile {
+                path: Path::from(CREATED_TEST_FILE_PATH),
+            }
+            .into(),
+        })
+        .expect("send open file");
+
+    let f = wait_for_result_value!(recv_qu, 0, CmplKind::OpenedFileHandle(r) => r);
+
+    log::debug!("got file handle: {f:?}");
+    assert_eq!(f.size, CREATED_TEST_DATA.len());
+
+    send_qu
+        .post(Command {
+            id: 1,
+            kind: ResizeFile {
+                handle: f.handle,
+                new_size,
+            }
+            .into(),
+        })
+        .expect("send resize");
+
+    wait_for_success(recv_qu, 1);
+
+    // Validate the original data
+    let mut data = vec![0u8; CREATED_TEST_DATA.len()];
+    send_qu
+        .post(Command {
+            id: 2,
+            kind: ReadFile {
+                src_handle: f.handle,
+                src_offset: 0,
+                dst_buffer: BufferMut::from(&mut data[..]),
+            }
+            .into(),
+        })
+        .expect("send read file");
+
+    wait_for_success(recv_qu, 2);
+    assert_eq!(&data, &CREATED_TEST_DATA[..]);
+
+    // Validate that the new bytes are zero
+    let mut new_data = vec![0u8; new_size - CREATED_TEST_DATA.len()];
+    send_qu
+        .post(Command {
+            id: 3,
+            kind: ReadFile {
+                src_handle: f.handle,
+                src_offset: CREATED_TEST_DATA.len(),
+                dst_buffer: BufferMut::from(&mut new_data[..]),
+            }
+            .into(),
+        })
+        .expect("send read file");
+
+    wait_for_success(recv_qu, 3);
+    assert!(new_data.iter().all(|&byte| byte == 0));
+
+    send_qu
+        .post(Command {
+            id: 4,
+            kind: CloseFile { handle: f.handle }.into(),
+        })
+        .expect("send close file");
+
+    wait_for_success(recv_qu, 4);
+
+    // Reopen the file and check the size
+    send_qu
+        .post(Command {
+            id: 5,
+            kind: OpenFile {
+                path: Path::from(CREATED_TEST_FILE_PATH),
+            }
+            .into(),
+        })
+        .expect("send open file");
+
+    let f = wait_for_result_value!(recv_qu, 5, CmplKind::OpenedFileHandle(r) => r);
+
+    log::debug!("got file handle: {f:?}");
+    assert_eq!(f.size, new_size);
+
+    send_qu
+        .post(Command {
+            id: 6,
+            kind: CloseFile { handle: f.handle }.into(),
+        })
+        .expect("send close file");
+
+    wait_for_success(recv_qu, 6);
+}
     send_qu
         .post(Command {
             id: 2,

--- a/api_tests/src/files.rs
+++ b/api_tests/src/files.rs
@@ -2,7 +2,7 @@ use kapi::{
     commands::{
         CloseFile, Command, CreateFile, DeleteFile, OpenFile, ReadFile, ResizeFile, WriteFile,
     },
-    completions::{Completion, ErrorCode, Kind as CmplKind, OpenedFileHandle},
+    completions::{Completion, ErrorCode, Kind as CmplKind},
     queue::Queue,
     system_calls::yield_now,
     Buffer, BufferMut, FileHandle, Path,
@@ -40,19 +40,8 @@ fn open_close(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
         })
         .expect("send open file");
 
-    let mut f: Option<OpenedFileHandle> = None;
-    while f.is_none() {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 0);
-            match c.kind {
-                CmplKind::OpenedFileHandle(r) => f = Some(r),
-                _ => panic!("unexpected completion: {c:?}"),
-            }
-        }
-        yield_now();
-    }
+    let f = wait_for_result_value!(recv_qu, 0, CmplKind::OpenedFileHandle(r) => r);
 
-    let f = f.unwrap();
     log::debug!("got file handle: {f:?}");
     assert!(f.size > 0);
 
@@ -81,19 +70,8 @@ fn create_close_delete(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
         })
         .expect("send create file");
 
-    let mut f: Option<OpenedFileHandle> = None;
-    while f.is_none() {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 0);
-            match c.kind {
-                CmplKind::OpenedFileHandle(r) => f = Some(r),
-                _ => panic!("unexpected completion: {c:?}"),
-            }
-        }
-        yield_now();
-    }
+    let f = wait_for_result_value!(recv_qu, 0, CmplKind::OpenedFileHandle(r) => r);
 
-    let f = f.unwrap();
     log::debug!("got file handle: {f:?}");
     assert_eq!(f.size, 512);
 
@@ -162,19 +140,8 @@ fn open_read_close(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
         })
         .expect("send open file");
 
-    let mut f: Option<OpenedFileHandle> = None;
-    while f.is_none() {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 0);
-            match c.kind {
-                CmplKind::OpenedFileHandle(r) => f = Some(r),
-                _ => panic!("unexpected completion: {c:?}"),
-            }
-        }
-        yield_now();
-    }
+    let f = wait_for_result_value!(recv_qu, 0, CmplKind::OpenedFileHandle(r) => r);
 
-    let f = f.unwrap();
     log::debug!("got file handle: {f:?}");
     assert_eq!(f.size, KNOWN_TEST_DATA.len());
 
@@ -216,19 +183,8 @@ fn open_partial_read_close(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>
         })
         .expect("send open file");
 
-    let mut f: Option<OpenedFileHandle> = None;
-    while f.is_none() {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 0);
-            match c.kind {
-                CmplKind::OpenedFileHandle(r) => f = Some(r),
-                _ => panic!("unexpected completion: {c:?}"),
-            }
-        }
-        yield_now();
-    }
+    let f = wait_for_result_value!(recv_qu, 0, CmplKind::OpenedFileHandle(r) => r);
 
-    let f = f.unwrap();
     log::debug!("got file handle: {f:?}");
     assert_eq!(f.size, KNOWN_TEST_DATA.len());
 
@@ -280,19 +236,8 @@ fn create_write_close(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
         })
         .expect("send create file");
 
-    let mut f: Option<OpenedFileHandle> = None;
-    while f.is_none() {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 0);
-            match c.kind {
-                CmplKind::OpenedFileHandle(r) => f = Some(r),
-                _ => panic!("unexpected completion: {c:?}"),
-            }
-        }
-        yield_now();
-    }
+    let f = wait_for_result_value!(recv_qu, 0, CmplKind::OpenedFileHandle(r) => r);
 
-    let f = f.unwrap();
     log::debug!("got file handle: {f:?}");
     assert_eq!(f.size, CREATED_TEST_DATA.len());
 
@@ -329,19 +274,8 @@ fn open_read_close_created_file(send_qu: &Queue<Command>, recv_qu: &Queue<Comple
         })
         .expect("send open file");
 
-    let mut f: Option<OpenedFileHandle> = None;
-    while f.is_none() {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 0);
-            match c.kind {
-                CmplKind::OpenedFileHandle(r) => f = Some(r),
-                _ => panic!("unexpected completion: {c:?}"),
-            }
-        }
-        yield_now();
-    }
+    let f = wait_for_result_value!(recv_qu, 0, CmplKind::OpenedFileHandle(r) => r);
 
-    let f = f.unwrap();
     log::debug!("got file handle: {f:?}");
     assert_eq!(f.size, CREATED_TEST_DATA.len());
 
@@ -383,19 +317,8 @@ fn open_read_past_end_close_created_file(send_qu: &Queue<Command>, recv_qu: &Que
         })
         .expect("send open file");
 
-    let mut f: Option<OpenedFileHandle> = None;
-    while f.is_none() {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 0);
-            match c.kind {
-                CmplKind::OpenedFileHandle(r) => f = Some(r),
-                _ => panic!("unexpected completion: {c:?}"),
-            }
-        }
-        yield_now();
-    }
+    let f = wait_for_result_value!(recv_qu, 0, CmplKind::OpenedFileHandle(r) => r);
 
-    let f = f.unwrap();
     log::debug!("got file handle: {f:?}");
     assert_eq!(f.size, CREATED_TEST_DATA.len());
 
@@ -436,19 +359,8 @@ fn open_write_past_end_close_created_file(send_qu: &Queue<Command>, recv_qu: &Qu
         })
         .expect("send open file");
 
-    let mut f: Option<OpenedFileHandle> = None;
-    while f.is_none() {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 0);
-            match c.kind {
-                CmplKind::OpenedFileHandle(r) => f = Some(r),
-                _ => panic!("unexpected completion: {c:?}"),
-            }
-        }
-        yield_now();
-    }
+    let f = wait_for_result_value!(recv_qu, 0, CmplKind::OpenedFileHandle(r) => r);
 
-    let f = f.unwrap();
     log::debug!("got file handle: {f:?}");
     assert_eq!(f.size, CREATED_TEST_DATA.len());
 

--- a/api_tests/src/files.rs
+++ b/api_tests/src/files.rs
@@ -8,7 +8,7 @@ use kapi::{
     Buffer, BufferMut, FileHandle, Path,
 };
 
-use crate::{wait_for_error_response, Testable};
+use crate::{wait_for_error_response, wait_for_success, Testable};
 
 pub const TESTS: &[&dyn Testable] = &[
     &open_close,
@@ -63,14 +63,7 @@ fn open_close(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
         })
         .expect("send close file");
 
-    loop {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 1);
-            assert_eq!(c.kind, CmplKind::Success);
-            break;
-        }
-        yield_now();
-    }
+    wait_for_success(recv_qu, 1);
 }
 
 fn create_close_delete(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
@@ -111,14 +104,7 @@ fn create_close_delete(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
         })
         .expect("send close file");
 
-    loop {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 1);
-            assert_eq!(c.kind, CmplKind::Success);
-            break;
-        }
-        yield_now();
-    }
+    wait_for_success(recv_qu, 1);
 
     send_qu
         .post(Command {
@@ -127,14 +113,7 @@ fn create_close_delete(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
         })
         .expect("send delete file");
 
-    loop {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 2);
-            assert_eq!(c.kind, CmplKind::Success);
-            break;
-        }
-        yield_now();
-    }
+    wait_for_success(recv_qu, 2);
 }
 
 fn fail_to_create_existing(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
@@ -212,14 +191,7 @@ fn open_read_close(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
         })
         .expect("send read file");
 
-    loop {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 1);
-            assert_eq!(c.kind, CmplKind::Success);
-            break;
-        }
-        yield_now();
-    }
+    wait_for_success(recv_qu, 1);
 
     assert_eq!(data, KNOWN_TEST_DATA);
 
@@ -230,14 +202,7 @@ fn open_read_close(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
         })
         .expect("send close file");
 
-    loop {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 1);
-            assert_eq!(c.kind, CmplKind::Success);
-            break;
-        }
-        yield_now();
-    }
+    wait_for_success(recv_qu, 1);
 }
 
 fn open_partial_read_close(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
@@ -282,14 +247,7 @@ fn open_partial_read_close(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>
             })
             .expect("send read file");
 
-        loop {
-            if let Some(c) = recv_qu.poll() {
-                assert_eq!(c.response_to_id, 1);
-                assert_eq!(c.kind, CmplKind::Success);
-                break;
-            }
-            yield_now();
-        }
+        wait_for_success(recv_qu, 1);
 
         assert_eq!(data, KNOWN_TEST_DATA[offset..offset + data.len()]);
     }
@@ -301,14 +259,7 @@ fn open_partial_read_close(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>
         })
         .expect("send close file");
 
-    loop {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 1);
-            assert_eq!(c.kind, CmplKind::Success);
-            break;
-        }
-        yield_now();
-    }
+    wait_for_success(recv_qu, 1);
 }
 
 const CREATED_TEST_FILE_PATH: &str = "/volumes/root/test-file";
@@ -364,14 +315,7 @@ fn create_write_close(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
         })
         .expect("send close file");
 
-    loop {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 1);
-            assert_eq!(c.kind, CmplKind::Success);
-            break;
-        }
-        yield_now();
-    }
+    wait_for_success(recv_qu, 1);
 }
 
 fn open_read_close_created_file(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
@@ -414,14 +358,7 @@ fn open_read_close_created_file(send_qu: &Queue<Command>, recv_qu: &Queue<Comple
         })
         .expect("send read file");
 
-    loop {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 1);
-            assert_eq!(c.kind, CmplKind::Success);
-            break;
-        }
-        yield_now();
-    }
+    wait_for_success(recv_qu, 1);
 
     assert_eq!(&data, CREATED_TEST_DATA);
 
@@ -432,14 +369,7 @@ fn open_read_close_created_file(send_qu: &Queue<Command>, recv_qu: &Queue<Comple
         })
         .expect("send close file");
 
-    loop {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 1);
-            assert_eq!(c.kind, CmplKind::Success);
-            break;
-        }
-        yield_now();
-    }
+    wait_for_success(recv_qu, 1);
 }
 
 fn open_read_past_end_close_created_file(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
@@ -492,14 +422,7 @@ fn open_read_past_end_close_created_file(send_qu: &Queue<Command>, recv_qu: &Que
         })
         .expect("send close file");
 
-    loop {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 1);
-            assert_eq!(c.kind, CmplKind::Success);
-            break;
-        }
-        yield_now();
-    }
+    wait_for_success(recv_qu, 1);
 }
 
 fn open_write_past_end_close_created_file(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
@@ -552,14 +475,7 @@ fn open_write_past_end_close_created_file(send_qu: &Queue<Command>, recv_qu: &Qu
         })
         .expect("send close file");
 
-    loop {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 1);
-            assert_eq!(c.kind, CmplKind::Success);
-            break;
-        }
-        yield_now();
-    }
+    wait_for_success(recv_qu, 1);
 }
 
 fn delete_created_file(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
@@ -573,14 +489,7 @@ fn delete_created_file(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
         })
         .expect("send delete file");
 
-    loop {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 2);
-            assert_eq!(c.kind, CmplKind::Success);
-            break;
-        }
-        yield_now();
-    }
+    wait_for_success(recv_qu, 2);
 
     //make sure it is gone
 

--- a/api_tests/src/files.rs
+++ b/api_tests/src/files.rs
@@ -15,11 +15,11 @@ use crate::{wait_for_error_response, wait_for_success, Testable};
 pub const TESTS: &[&dyn Testable] = &[
     &open_close,
     &fail_to_open_not_existing,
+    &open_read_close,
+    &open_partial_read_close,
     &fail_to_close_bad_handle,
     &create_close_delete,
     &fail_to_create_existing,
-    &open_read_close,
-    &open_partial_read_close,
     &create_write_close,
     &open_read_close_created_file,
     &open_read_past_end_close_created_file,
@@ -31,7 +31,7 @@ pub const TESTS: &[&dyn Testable] = &[
     &fail_to_read_bad_handle,
     &fail_to_write_bad_handle,
     &fail_to_resize_bad_handle,
-    &data_round_trip,
+    &data_round_trip_without_close,
 ];
 
 fn open_close(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
@@ -707,7 +707,7 @@ fn fail_to_close_bad_handle(send_qu: &Queue<Command>, recv_qu: &Queue<Completion
     wait_for_error_response(recv_qu, 0, ErrorCode::InvalidId);
 }
 
-fn data_round_trip(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
+fn data_round_trip_without_close(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
     let path = Path::from("/volumes/root/tmp-test-file");
 
     send_qu

--- a/api_tests/src/main.rs
+++ b/api_tests/src/main.rs
@@ -44,6 +44,17 @@ pub fn wait_for_error_response(recv_qu: &Queue<Completion>, id: u16, code: Error
     }
 }
 
+pub fn wait_for_success(recv_qu: &Queue<Completion>, id: u16) {
+    loop {
+        if let Some(c) = recv_qu.poll() {
+            assert_eq!(c.response_to_id, id);
+            assert_eq!(c.kind, CmplKind::Success);
+            break;
+        }
+        yield_now();
+    }
+}
+
 pub fn test_runner(
     tests: &[&[&dyn Testable]],
     send_qu: &Queue<Command>,

--- a/api_tests/src/main.rs
+++ b/api_tests/src/main.rs
@@ -88,6 +88,7 @@ fn cmd_test(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
 
 // TODO: new test that sends lots of messages to make sure that queue wrapping works correctly
 
+mod files;
 mod processes;
 mod queues;
 mod threads;
@@ -129,6 +130,7 @@ pub extern "C" fn _start(
             queues::TESTS,
             threads::TESTS,
             processes::TESTS,
+            files::TESTS,
         ],
         &send_qu,
         &recv_qu,

--- a/api_tests/src/processes.rs
+++ b/api_tests/src/processes.rs
@@ -8,7 +8,7 @@ use kapi::{
     Buffer, Path, ProcessId,
 };
 
-use crate::Testable;
+use crate::{wait_for_error_response, Testable};
 
 pub const TESTS: &[&dyn Testable] = &[
     &basic,
@@ -146,14 +146,7 @@ fn fail_binary_not_found(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) 
         })
         .expect("send spawn process");
 
-    loop {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 0);
-            assert_eq!(c.kind, CmplKind::Err(ErrorCode::NotFound));
-            break;
-        }
-        yield_now();
-    }
+    wait_for_error_response(recv_qu, 0, ErrorCode::NotFound);
 }
 
 fn fail_invalid_path_ptr(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
@@ -172,14 +165,7 @@ fn fail_invalid_path_ptr(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) 
         })
         .expect("send spawn process");
 
-    loop {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 0);
-            assert_eq!(c.kind, CmplKind::Err(ErrorCode::InvalidPointer));
-            break;
-        }
-        yield_now();
-    }
+    wait_for_error_response(recv_qu, 0, ErrorCode::InvalidPointer);
 }
 
 fn fail_invalid_parameter_ptr(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
@@ -198,14 +184,7 @@ fn fail_invalid_parameter_ptr(send_qu: &Queue<Command>, recv_qu: &Queue<Completi
         })
         .expect("send spawn process");
 
-    loop {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 0);
-            assert_eq!(c.kind, CmplKind::Err(ErrorCode::InvalidPointer));
-            break;
-        }
-        yield_now();
-    }
+    wait_for_error_response(recv_qu, 0, ErrorCode::InvalidPointer);
 }
 
 fn basic_kill(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
@@ -280,14 +259,7 @@ fn fail_to_kill_bad_id(send_qu: &Queue<Command>, recv_qu: &Queue<Completion>) {
         })
         .expect("send kill process");
 
-    loop {
-        if let Some(c) = recv_qu.poll() {
-            assert_eq!(c.response_to_id, 0);
-            assert_eq!(c.kind, CmplKind::Err(ErrorCode::InvalidId));
-            break;
-        }
-        yield_now();
-    }
+    wait_for_error_response(recv_qu, 0, ErrorCode::InvalidId);
 }
 
 fn basic_heap(_send_qu: &Queue<Command>, _recv_qu: &Queue<Completion>) {

--- a/kapi/src/commands.rs
+++ b/kapi/src/commands.rs
@@ -1,6 +1,6 @@
 //! Asynchronous commands that can be submitted to the kernel from user-space via a [crate::queue::Queue].
 
-use crate::{queue::QueueId, Buffer, BufferMut, FileHandle, Path, ProcessId, ThreadId};
+use crate::{queue::QueueId, Buffer, BufferMut, FileHandle, FileUSize, Path, ProcessId, ThreadId};
 
 macro_rules! impl_into_kind {
     ($t:ident) => {
@@ -173,7 +173,7 @@ pub struct ReadFile {
     /// The file to read from.
     pub src_handle: FileHandle,
     /// An offset in bytes from the start of the file to start reading from.
-    pub src_offset: usize,
+    pub src_offset: FileUSize,
     /// The destination buffer to fill. This buffer *must* stay valid until the completion is
     /// received for the read to be safe.
     pub dst_buffer: BufferMut,
@@ -191,7 +191,7 @@ pub struct WriteFile {
     /// The file to write to.
     pub dst_handle: FileHandle,
     /// An offset in bytes from the start of the file to start writing to.
-    pub dst_offset: usize,
+    pub dst_offset: FileUSize,
     /// The source buffer to read from. This buffer *must* stay valid until the completion is
     /// received for the write to be safe.
     pub src_buffer: Buffer,
@@ -210,7 +210,7 @@ pub struct ResizeFile {
     /// The file to resize.
     pub handle: FileHandle,
     /// The new size of the file in bytes.
-    pub new_size: usize,
+    pub new_size: FileUSize,
 }
 impl_into_kind!(ResizeFile);
 

--- a/kapi/src/commands.rs
+++ b/kapi/src/commands.rs
@@ -1,6 +1,6 @@
 //! Asynchronous commands that can be submitted to the kernel from user-space via a [crate::queue::Queue].
 
-use crate::{queue::QueueId, Buffer, Path, ProcessId, ThreadId};
+use crate::{queue::QueueId, Buffer, FileHandle, Path, ProcessId, ThreadId};
 
 macro_rules! impl_into_kind {
     ($t:ident) => {
@@ -135,6 +135,105 @@ pub struct KillProcess {
 }
 impl_into_kind!(KillProcess);
 
+/// Create a new file in some file system.
+/// [Completion Type][crate::completions::OpenedFileHandle]
+///
+/// If the file already exists, it may have a different size than `initial_size`.
+/// The correct, current file size will always be returned in the completion.
+#[repr(C)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateFile {
+    /// The path that the file will be created under.
+    pub path: Path,
+    /// The initial size of the file in bytes.
+    pub initial_size: usize,
+    /// If true, the file will be opened if it already exists. If false, an error will be returned if the file exists.
+    pub open_if_exists: bool,
+}
+impl_into_kind!(CreateFile);
+
+/// Open a file that already exists on some file system.
+/// [Completion Type][crate::completions::OpenedFileHandle]
+#[repr(C)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenFile {
+    /// The path to the file to open.
+    pub path: Path,
+}
+impl_into_kind!(OpenFile);
+
+/// Read data from a file into a buffer.
+/// [Completion Type][crate::completions::BytesProcessed]
+///
+/// At most the entire buffer is filled with data from the file, starting from the offset.
+/// If the length to read extends past the end of the file, only the data up to the end will be
+/// transfered.
+#[repr(C)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadFile {
+    /// The file to read from.
+    pub src_handle: FileHandle,
+    /// An offset in bytes from the start of the file to start reading from.
+    pub src_offset: usize,
+    /// The destination buffer to fill. This buffer *must* stay valid until the completion is
+    /// received for the read to be safe.
+    pub dst_buffer: Buffer,
+}
+impl_into_kind!(ReadFile);
+
+/// Write data from a buffer into a file.
+/// [Completion Type][crate::completions::BytesProcessed]
+///
+/// At most the entire buffer is written to the file, starting from the offset.
+/// If the length to write extends past the end of the file, an error will occur.
+#[repr(C)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriteFile {
+    /// The file to write to.
+    pub dst_handle: FileHandle,
+    /// An offset in bytes from the start of the file to start writing to.
+    pub dst_offset: usize,
+    /// The source buffer to read from. This buffer *must* stay valid until the completion is
+    /// received for the write to be safe.
+    pub src_buffer: Buffer,
+}
+impl_into_kind!(WriteFile);
+
+/// Resize a file.
+/// [Completion Type][crate::completions::Success]
+///
+/// If the new size is smaller than the current size, the file will be truncated and
+/// the data discarded. If the new size is larger than the current, the file will have that many
+/// zeros appended to the end.
+#[repr(C)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResizeFile {
+    /// The file to resize.
+    pub handle: FileHandle,
+    /// The new size of the file in bytes.
+    pub new_size: usize,
+}
+impl_into_kind!(ResizeFile);
+
+/// Close a file handle.
+/// [Completion Type][crate::completions::Success]
+#[repr(C)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CloseFile {
+    /// The file handle to close.
+    pub handle: FileHandle,
+}
+impl_into_kind!(CloseFile);
+
+/// Delete a file.
+/// [Completion Type][crate::completions::Success]
+#[repr(C)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeleteFile {
+    // TODO
+}
+impl_into_kind!(DeleteFile);
+
 /// Type of command and any required parameters.
 ///
 /// Each command is further documented on the inner parameter struct.
@@ -159,6 +258,14 @@ pub enum Kind {
     SpawnProcess(SpawnProcess),
     WatchProcess(WatchProcess),
     KillProcess(KillProcess),
+
+    CreateFile(CreateFile),
+    OpenFile(OpenFile),
+    ReadFile(ReadFile),
+    WriteFile(WriteFile),
+    ResizeFile(ResizeFile),
+    DeleteFile(DeleteFile),
+    CloseFile(CloseFile),
 }
 
 /// A command that can be sent to the kernel.

--- a/kapi/src/completions.rs
+++ b/kapi/src/completions.rs
@@ -26,8 +26,6 @@ pub enum ErrorCode {
 
     /// The system has run out of memory.
     OutOfMemory,
-    /// The resource referenced could not be found.
-    NotFound,
     /// An argument was out of bounds.
     OutOfBounds,
     /// The kernel has run out of free IDs for a resource.
@@ -39,7 +37,7 @@ pub enum ErrorCode {
     /// The underlying device returned an error.
     Device,
 
-    /// An ID was provided that was not known to the kernel.
+    /// An ID (or handle) was provided that was not known to the kernel.
     InvalidId,
     /// A size was provided that is invalid for the operation.
     InvalidSize,
@@ -48,6 +46,10 @@ pub enum ErrorCode {
     /// A string was provided that was not valid UTF-8.
     InvalidUtf8,
 
+    /// The resource referenced could not be found.
+    NotFound,
+    /// The requsted creation cannot occur because the object already exists.
+    AlreadyExists,
     /// The object was still in use when its destruction was requested.
     InUse,
 
@@ -133,14 +135,7 @@ pub struct OpenedFileHandle {
     /// The size of the file in bytes.
     pub size: usize,
 }
-
-/// Response to a [crate::commands::ReadFile] or [crate::commands::WriteFile] command.
-#[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BytesProcessed {
-    /// Actual number of bytes read or written.
-    pub num_bytes: usize,
-}
+impl_into_kind!(OpenedFileHandle);
 
 /// Type of completion and any resulting values returned by the command.
 #[repr(u16)]
@@ -152,14 +147,14 @@ pub enum Kind {
     Invalid = 0,
     /// General success result for commands that don't return any values.
     Success = 1,
+    /// The command failed to complete successfully.
+    Err(ErrorCode),
     Test(Test),
     NewQueue(NewQueue),
     NewThread(NewThread),
     ThreadExit(ThreadExit),
     NewProcess(NewProcess),
     OpenedFileHandle(OpenedFileHandle),
-    /// The command failed to complete successfully.
-    Err(ErrorCode),
 }
 
 /// A completion/event that can be receved from the kernel.

--- a/kapi/src/completions.rs
+++ b/kapi/src/completions.rs
@@ -133,7 +133,7 @@ pub struct OpenedFileHandle {
     /// The newly opened handle.
     pub handle: FileHandle,
     /// The size of the file in bytes.
-    pub size: usize,
+    pub size: u64,
 }
 impl_into_kind!(OpenedFileHandle);
 

--- a/kapi/src/completions.rs
+++ b/kapi/src/completions.rs
@@ -1,7 +1,7 @@
 //! Asynchronous results that can be received in user-space from the kernel via a [crate::queue::Queue].
 use bytemuck::Contiguous;
 
-use crate::{queue::QueueId, ProcessId, ThreadId};
+use crate::{queue::QueueId, FileHandle, ProcessId, ThreadId};
 
 macro_rules! impl_into_kind {
     ($t:ident) => {
@@ -124,6 +124,24 @@ pub struct NewProcess {
 }
 impl_into_kind!(NewProcess);
 
+/// Response to a [crate::commands::CreateFile] command.
+#[repr(C)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenedFileHandle {
+    /// The newly opened handle.
+    pub handle: FileHandle,
+    /// The size of the file in bytes.
+    pub size: usize,
+}
+
+/// Response to a [crate::commands::ReadFile] or [crate::commands::WriteFile] command.
+#[repr(C)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BytesProcessed {
+    /// Actual number of bytes read or written.
+    pub num_bytes: usize,
+}
+
 /// Type of completion and any resulting values returned by the command.
 #[repr(u16)]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -139,6 +157,7 @@ pub enum Kind {
     NewThread(NewThread),
     ThreadExit(ThreadExit),
     NewProcess(NewProcess),
+    OpenedFileHandle(OpenedFileHandle),
     /// The command failed to complete successfully.
     Err(ErrorCode),
 }

--- a/kapi/src/lib.rs
+++ b/kapi/src/lib.rs
@@ -12,6 +12,11 @@ pub type ThreadId = u32;
 /// The process-unique ID of an open file.
 pub type FileHandle = NonZeroU32;
 
+/// An unsigned integer suitably large for a file size or offset value.
+pub type FileUSize = u64;
+/// An signed integer suitably large for a file offset value.
+pub type FileISize = i64;
+
 pub mod commands;
 pub mod completions;
 pub mod queue;

--- a/kapi/src/lib.rs
+++ b/kapi/src/lib.rs
@@ -9,6 +9,8 @@ use core::ptr::null;
 pub type ProcessId = NonZeroU32;
 /// The system-wide unique ID of a thread.
 pub type ThreadId = u32;
+/// The process-unique ID of an open file.
+pub type FileHandle = NonZeroU32;
 
 pub mod commands;
 pub mod completions;

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -21,6 +21,7 @@ byteorder = { version = "1", default-features = false }
 bitvec = { version = "1", default-features = false }
 bytemuck = { version = "1", features = ["derive"] }
 widestring = { version = "1", default-features = false, features = ["alloc"] }
+itertools = { version = "0.13", default-features = false, features = ["use_alloc"] }
 
 # logging / errors
 log = "0.4"

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -103,6 +103,9 @@ impl Error {
                 }
                 | MemoryError::Map {
                     source: memory::paging::MapError::CopyFromUnmapped { .. },
+                }
+                | MemoryError::Map {
+                    source: memory::paging::MapError::ExpectedMapping { .. },
                 } => ErrorCode::InvalidPointer,
                 _ => ErrorCode::Internal,
             },

--- a/kernel/src/fs/fat/data.rs
+++ b/kernel/src/fs/fat/data.rs
@@ -8,6 +8,8 @@ use bytemuck::{Pod, Zeroable};
 use snafu::Snafu;
 use widestring::Utf16Str;
 
+pub type ClusterIndex = u16;
+
 /// A entry in the partition table found in the MBR.
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone, Zeroable, Pod)]
@@ -199,8 +201,7 @@ impl LongDirEntry {
     }
 }
 
-pub type ClusterIndex = u16;
-
+// TODO: Since direct == cluster index 0, this is unnecessary
 #[derive(Debug)]
 pub enum DirectorySource {
     Direct(BlockAddress),

--- a/kernel/src/fs/fat/mod.rs
+++ b/kernel/src/fs/fat/mod.rs
@@ -1,12 +1,12 @@
 //! Support for the FAT filesystem for QEMU
 //! Currently this only supports FAT16.
 // See <qemu-src>/block/vvfat.c
-
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use async_recursion::async_recursion;
 use async_trait::async_trait;
 
-use futures::{Stream, StreamExt};
+use bytemuck::bytes_of_mut;
+use futures::{Stream, StreamExt, TryStream, TryStreamExt};
 use kapi::FileUSize;
 use smallvec::SmallVec;
 use snafu::{ensure, OptionExt, ResultExt};
@@ -14,8 +14,7 @@ use snafu::{ensure, OptionExt, ResultExt};
 use crate::{
     error::{self, Error},
     fs::BadMetadataSnafu,
-    memory::{PhysicalAddress, PAGE_SIZE},
-    registry::{self, registry_mut, Path, RegistryError, RegistryHandler},
+    registry::{self, registry_mut, Path, RegistryHandler},
     storage::{block_cache::BlockCache, BlockAddress, BlockStore},
 };
 
@@ -24,118 +23,7 @@ use super::{File, FsError};
 mod data;
 use data::*;
 
-const CACHE_SIZE: usize = 256 /* pages */;
-
-struct FatFile {
-    cache: Arc<BlockCache>,
-    params: VolumeParams,
-    start_cluster_number: u16,
-    file_size: u32,
-}
-
-#[async_trait]
-impl File for FatFile {
-    fn len(&self) -> FileUSize {
-        self.file_size as FileUSize
-    }
-
-    /// Read bytes starting from `src_offset` in the file into the buffers in `destinations`.
-    /// The total length of `destinations` must fit within the file or the read will fail with an OutOfBounds error.
-    /// No IO will occur in this case.
-    async fn read<'v, 'dest>(
-        &self,
-        src_offset: FileUSize,
-        destinations: &'v [&'dest mut [u8]],
-    ) -> Result<(), Error> {
-        todo!()
-    }
-
-    /// Write bytes starting at `dst_offset` in the file from the buffers in `sources`.
-    /// The total length of `sources` must fit within the file or the write will fail with an OutOfBounds error.
-    /// No IO will occur in this case.
-    async fn write<'v, 'src>(
-        &mut self,
-        dst_offset: FileUSize,
-        sources: &'v [&'src [u8]],
-    ) -> Result<(), Error> {
-        todo!()
-    }
-
-    async fn load_pages(
-        &mut self,
-        src_offset: u64,
-        dest_address: PhysicalAddress,
-        num_pages: usize,
-    ) -> Result<(), Error> {
-        // assume: src_offset is page aligned and chunks go evenly into pages, so we never start in the middle of a chunk
-        if src_offset > self.file_size as u64 {
-            return Err(Error::FileSystem {
-                reason: "load out of bounds".into(),
-                source: Box::new(FsError::OutOfBounds {
-                    value: src_offset as usize,
-                    bound: self.file_size as usize,
-                    message: "load_pages: source offset beyond end of file",
-                }),
-            });
-        }
-
-        let mut cur_cluster_num = self.start_cluster_number;
-        let mut cur_offset = 0;
-        let end_offset = (src_offset + (num_pages * PAGE_SIZE) as u64).min(self.file_size as u64);
-
-        // move to the start of the range to load
-        while cur_offset < src_offset {
-            self.cache
-                .copy_bytes(
-                    self.params.fat_start,
-                    (cur_cluster_num * 2) as usize,
-                    bytemuck::bytes_of_mut(&mut cur_cluster_num),
-                )
-                .await
-                .context(error::StorageSnafu {
-                    reason: "read FAT table",
-                })?;
-            cur_offset += self.params.bytes_per_cluster();
-            // TODO: possible to get the end-of-file cluster number here
-        }
-
-        // copy clusters until full
-        while cur_offset < end_offset {
-            // read the cluster into memory
-            // TODO: we need to make sure we don't copy past the end of the destination buffer!!
-            self.cache
-                .underlying_store()
-                .lock()
-                .await
-                .read_blocks(
-                    self.params.sector_for_cluster(cur_cluster_num),
-                    &[(
-                        dest_address.offset((cur_offset - src_offset) as isize),
-                        self.params.sectors_per_cluster as usize,
-                    )],
-                )
-                .await
-                .context(error::StorageSnafu {
-                    reason: "read data",
-                })?;
-
-            // move to next cluster
-            self.cache
-                .copy_bytes(
-                    self.params.fat_start,
-                    (cur_cluster_num * 2) as usize,
-                    bytemuck::bytes_of_mut(&mut cur_cluster_num),
-                )
-                .await
-                .context(error::StorageSnafu {
-                    reason: "read FAT table for next cluster",
-                })?;
-            cur_offset += self.params.bytes_per_cluster();
-        }
-
-        Ok(())
-    }
-}
+const CACHE_SIZE: usize = 512 /* pages */;
 
 #[derive(Debug, Clone)]
 struct VolumeParams {
@@ -166,7 +54,7 @@ impl VolumeParams {
         }
     }
 
-    const fn sector_for_cluster(&self, cluster_num: u16) -> BlockAddress {
+    const fn sector_for_cluster(&self, cluster_num: ClusterIndex) -> BlockAddress {
         BlockAddress(self.clusters_start.0 + cluster_num as u64 * self.sectors_per_cluster)
     }
 
@@ -175,13 +63,13 @@ impl VolumeParams {
     }
 }
 
-struct Handler {
-    cache: Arc<BlockCache>,
+struct FatFs {
+    cache: BlockCache,
     params: VolumeParams,
 }
 
-impl Handler {
-    async fn new(block_store: Box<dyn BlockStore>) -> Result<Handler, Error> {
+impl FatFs {
+    async fn new(block_store: Box<dyn BlockStore>) -> Result<FatFs, Error> {
         let cache = BlockCache::new(block_store, CACHE_SIZE)?;
 
         // read the relevant part of the MBR, starting at byte 446
@@ -242,29 +130,30 @@ impl Handler {
             reason: "validate boot sector",
         })?;
 
-        let hh = Handler {
-            cache: Arc::new(cache),
+        let hh = FatFs {
+            cache,
             params: VolumeParams::compute_from_bootsector(partition_addr, bootsector),
         };
         log::debug!("volume parameters = {:?}", hh.params);
 
-        hh.dir_entry_stream(DirectorySource::Direct(hh.params.root_directory_start))
-            .for_each(|e| async move {
-                match e {
-                    Ok(e) => {
-                        let c = e.cluster_num_lo;
-                        let sz = e.file_size;
-                        log::debug!(
-                            "{:?} {} : {} @ {c:x} + {sz}",
-                            e.attributes,
-                            unsafe { core::str::from_utf8_unchecked(&e.short_name) },
-                            e.long_name().unwrap(),
-                        )
-                    }
-                    Err(e) => log::error!("failed to read root directory entry: {e}"),
+        // debug log the root directory
+        /*hh.dir_entry_stream(DirectorySource::Direct(hh.params.root_directory_start))
+        .for_each(|e| async move {
+            match e {
+                Ok(e) => {
+                    let c = e.cluster_num_lo;
+                    let sz = e.file_size;
+                    log::debug!(
+                        "{:?} {} : {} @ {c:x} + {sz}",
+                        e.attributes,
+                        unsafe { core::str::from_utf8_unchecked(&e.short_name) },
+                        e.long_name().unwrap(),
+                    )
                 }
-            })
-            .await;
+                Err(e) => log::error!("failed to read root directory entry: {e}"),
+            }
+        })
+        .await;*/
 
         /* TODO:
          * - traverse directories to locate a file
@@ -275,20 +164,113 @@ impl Handler {
 
         Ok(hh)
     }
-}
 
-fn compute_block_addr(source: &DirectorySource, params: &VolumeParams) -> BlockAddress {
-    match source {
-        DirectorySource::Direct(a) => *a,
-        DirectorySource::Clusters(i) => params.sector_for_cluster(*i),
+    /// Create a mapping <cluster index> -> (<buffer index>, <buffer offset>) from a vector
+    /// descriptor iterator (<buffer index>, <buffer length>) and the number of clusters total.
+    /// The mapping maps clusters to the *first* buffer they would affect.
+    fn cluster_to_buffer_vector_map(
+        &self,
+        mut buffer_vector: impl Iterator<Item = (usize, usize)>,
+        start_offset: usize,
+        num_clusters: usize,
+    ) -> Vec<(usize, usize)> {
+        let mut map = Vec::with_capacity(num_clusters);
+        let (mut current_buffer_index, mut current_buffer_length) =
+            buffer_vector.next().expect("buffer vector is non-empty");
+        let mut current_offset = 0;
+        let cluster_size = self.params.bytes_per_cluster() as usize;
+        for cluster in 0..num_clusters {
+            map.push((current_buffer_index, current_offset));
+            // log::trace!("{cluster} => {current_buffer_index} + {current_offset}");
+            let mut src_offset = if cluster == 0 { start_offset } else { 0 };
+            loop {
+                let src_remaining = cluster_size - src_offset;
+                let dst_remaining = current_buffer_length - current_offset;
+                let len = src_remaining.min(dst_remaining);
+                current_offset += len;
+                if current_offset == current_buffer_length {
+                    current_offset = 0;
+                    match buffer_vector.next() {
+                        Some(d) => (current_buffer_index, current_buffer_length) = d,
+                        None => break,
+                    }
+                }
+                src_offset += len;
+                if src_offset == cluster_size {
+                    // we're finished with this cluster, move to the next one
+                    break;
+                }
+            }
+        }
+        map
     }
-}
 
-impl Handler {
+    /// Determine if the cluster number is a special value representing the end of the chain.
+    fn cluster_number_is_end(&self, cluster_number: ClusterIndex) -> bool {
+        // TODO: this only works for FAT16.
+        cluster_number >= 0xfff8
+    }
+
+    /// Create a stream of block addresses locating the start of each cluster in a cluster chain
+    /// found in the FAT, and the relative cluster index from the start of the chain.
+    fn cluster_address_stream(
+        &self,
+        start_cluster_number: ClusterIndex,
+    ) -> impl TryStream<Ok = (BlockAddress, usize), Error = Error> + '_ {
+        futures::stream::try_unfold(
+            (start_cluster_number, 0),
+            move |(current_cluster_number, current_cluster_index)| async move {
+                if self.cluster_number_is_end(current_cluster_number) {
+                    Ok(None)
+                } else {
+                    let current_cluster_address =
+                        self.params.sector_for_cluster(current_cluster_number);
+                    let mut next_cluster_number = ClusterIndex::MAX;
+                    self.cache
+                        .copy_bytes(
+                            self.params.fat_start,
+                            (current_cluster_number * 2) as usize,
+                            bytes_of_mut(&mut next_cluster_number),
+                        )
+                        .await
+                        .context(error::StorageSnafu {
+                            reason: "read FAT table for next cluster",
+                        })?;
+                    Ok(Some((
+                        (current_cluster_address, current_cluster_index),
+                        (next_cluster_number, current_cluster_index + 1),
+                    )))
+                }
+            },
+        )
+    }
+
+    // fn dir_entry_stream2(&self, start_cluster_number: u16) -> impl TryStream<Ok = LongDirEntry, Error = Error> + '_ {
+    //     self.cluster_address_stream(start_cluster_number)
+    //         .and_then(|block_addr| async move {
+    //             let mut block = Vec::with_capacity(self.params.bytes_per_cluster() as usize);
+    //             block.resize(self.params.bytes_per_cluster() as usize, 0);
+    //             self.cache.copy_bytes(block_addr, 0, &mut block)
+    //                 .await
+    //                 .context(error::StorageSnafu {
+    //                     reason: "read directory block"
+    //                 })?;
+    //             todo!()
+    //         })
+    //         .try_flatten()
+    // }
+
     fn dir_entry_stream(
         &self,
         source: DirectorySource,
     ) -> impl Stream<Item = Result<LongDirEntry, Error>> + '_ {
+        fn compute_block_addr(source: &DirectorySource, params: &VolumeParams) -> BlockAddress {
+            match source {
+                DirectorySource::Direct(a) => *a,
+                DirectorySource::Clusters(i) => params.sector_for_cluster(*i),
+            }
+        }
+
         // max # of bytes in offset before wrapping and moving to the next segment
         let size_of_segment = match source {
             DirectorySource::Direct(_) => self.cache.block_size(),
@@ -423,14 +405,171 @@ impl Handler {
     }
 }
 
+struct FatFile {
+    fs: Arc<FatFs>,
+    start_cluster_number: ClusterIndex,
+    file_size: u32,
+}
+
+impl FatFile {
+    /// Returns a stream of (cluster index from beginning of file, address of starting block in cluster)
+    /// over the range of clusters in start..end also relative to the start of the file
+    fn cluster_slice_stream(
+        &self,
+        start_cluster: usize,
+        end_cluster: usize,
+    ) -> impl TryStream<Ok = (BlockAddress, usize), Error = Error> + '_ {
+        self.fs
+            .cluster_address_stream(self.start_cluster_number)
+            .try_skip_while(move |(_, i)| futures::future::ok(*i < start_cluster))
+            .try_take_while(move |(_, i)| futures::future::ok(*i < end_cluster))
+    }
+}
+
+#[async_trait]
+impl File for FatFile {
+    fn len(&self) -> FileUSize {
+        self.file_size as FileUSize
+    }
+
+    /// Read bytes starting from `src_offset` in the file into the buffers in `destinations`.
+    /// The total length of `destinations` must fit within the file or the read will fail with an OutOfBounds error.
+    /// No IO will occur in this case.
+    async fn read<'v, 'dest>(
+        &self,
+        src_offset: FileUSize,
+        destinations: &'v mut [&'dest mut [u8]],
+    ) -> Result<(), Error> {
+        /// This is basically a &[&mut [u8]] slice, except you can get a mutable reference to any interior slice.
+        /// This is safe because we are only going to interact with only one interior slice at a time,
+        /// but we have to look sharable to be able to move into the async closure.
+        /// Since we construct this from a &mut rather than a &, we know that we have exclusive
+        /// access to the slice pointers, so it shouldn't be too big of a deal.
+        /// This is obviously only safe to use inside this function where we know exactly what will
+        /// happen to it.
+        #[derive(Copy, Clone)]
+        struct ReadDestSlice<'dst> {
+            ptr: *const &'dst mut [u8],
+            len: usize,
+        }
+
+        impl<'dst> From<&mut [&'dst mut [u8]]> for ReadDestSlice<'dst> {
+            fn from(value: &mut [&'dst mut [u8]]) -> Self {
+                Self {
+                    ptr: value.as_ptr(),
+                    len: value.len(),
+                }
+            }
+        }
+
+        impl<'dst> ReadDestSlice<'dst> {
+            fn get(&self, index: usize) -> &'dst mut [u8] {
+                assert!(index < self.len);
+                unsafe { self.ptr.add(index).read() }
+            }
+        }
+
+        unsafe impl Send for ReadDestSlice<'_> {}
+
+        let total_read_size: FileUSize = destinations.iter().map(|s| s.len() as FileUSize).sum();
+
+        if (src_offset + total_read_size) > self.len() {
+            return Err(Error::FileSystem {
+                reason: "read is out of bounds".into(),
+                source: Box::new(FsError::OutOfBounds {
+                    value: src_offset + total_read_size,
+                    bound: self.len(),
+                    message: "read",
+                }),
+            });
+        }
+
+        // compute the range of clusters we need to read
+        let start_cluster = src_offset.div_floor(self.fs.params.bytes_per_sector) as usize;
+        let start_offset = (src_offset % self.fs.params.bytes_per_sector) as usize;
+        let cluster_size = self.fs.params.bytes_per_cluster() as usize;
+        let num_clusters = (total_read_size as usize).div_ceil(cluster_size);
+        let end_cluster = start_cluster + num_clusters;
+
+        log::trace!("read: start_cluster={start_cluster}, start_offset={start_offset}, end_cluster={end_cluster}");
+
+        let cluster_map = &self.fs.cluster_to_buffer_vector_map(
+            destinations.iter().map(|s| s.len()).enumerate(),
+            start_offset,
+            num_clusters,
+        );
+
+        let dsts = ReadDestSlice::from(destinations);
+
+        self.cluster_slice_stream(start_cluster, end_cluster)
+            .try_for_each(move |(cluster_addr, cluster_index)| async move {
+                let (mut current_dst, mut current_dst_offset) = cluster_map[cluster_index];
+                let mut src_offset = if cluster_index == 0 {
+                    start_offset
+                } else {
+                    0
+                };
+                loop {
+                    let dst_buf = dsts.get(current_dst);
+                    let src_remaining = cluster_size - src_offset;
+                    let dst_remaining = dst_buf.len() - current_dst_offset;
+                    let len = src_remaining.min(dst_remaining);
+                    log::trace!("copy bytes from ({cluster_index}){cluster_addr}+{src_offset} to {current_dst}.{current_dst_offset} ({len} bytes)");
+                    self.fs
+                        .cache
+                        .copy_bytes(
+                            cluster_addr,
+                            src_offset,
+                            &mut dst_buf[current_dst_offset..current_dst_offset + len],
+                        )
+                        .await
+                        .context(error::StorageSnafu {
+                            reason: "copy bytes from file",
+                        })?;
+                    current_dst_offset += len;
+                    if current_dst_offset == dst_buf.len() {
+                        current_dst_offset = 0;
+                        current_dst += 1;
+                        if current_dst >= dsts.len {
+                            // we're done reading the file, this was the last cluster
+                            break Ok(());
+                        }
+                    }
+                    src_offset += len;
+                    if src_offset == cluster_size {
+                        // we're finished with this cluster, move to the next one
+                        break Ok(());
+                    }
+                }
+            })
+            .await
+    }
+
+    /// Write bytes starting at `dst_offset` in the file from the buffers in `sources`.
+    /// The total length of `sources` must fit within the file or the write will fail with an OutOfBounds error.
+    /// No IO will occur in this case.
+    async fn write<'v, 'src>(
+        &mut self,
+        _dst_offset: FileUSize,
+        _sources: &'v [&'src [u8]],
+    ) -> Result<(), Error> {
+        todo!()
+    }
+}
+
+struct Handler {
+    fs: Arc<FatFs>,
+}
+
 #[async_trait]
 impl RegistryHandler for Handler {
     async fn open_file(&self, subpath: &Path) -> Result<Box<dyn super::File>, Error> {
         log::trace!("attempting to locate {subpath} in FAT volume");
 
         let entry = self
+            .fs
             .find_entry_for_path(
-                DirectorySource::Direct(self.params.root_directory_start),
+                DirectorySource::Direct(self.fs.params.root_directory_start),
                 subpath.components(),
             )
             .await?
@@ -442,8 +581,7 @@ impl RegistryHandler for Handler {
         log::debug!("found entry {entry:?} for path {subpath}");
 
         Ok(Box::new(FatFile {
-            cache: self.cache.clone(),
-            params: self.params.clone(),
+            fs: self.fs.clone(),
             start_cluster_number: entry.cluster_num_lo,
             file_size: entry.file_size,
         }))
@@ -453,7 +591,12 @@ impl RegistryHandler for Handler {
 /// Mount a FAT filesystem present on `block_store` under `root_path` in the registry.
 pub async fn mount(root_path: &Path, block_store: Box<dyn BlockStore>) -> Result<(), Error> {
     registry_mut()
-        .register(root_path, Box::new(Handler::new(block_store).await?))
+        .register(
+            root_path,
+            Box::new(Handler {
+                fs: Arc::new(FatFs::new(block_store).await?),
+            }),
+        )
         .context(error::RegistrySnafu {
             reason: "register FAT filesystem",
         })

--- a/kernel/src/fs/fat/mod.rs
+++ b/kernel/src/fs/fat/mod.rs
@@ -7,6 +7,7 @@ use async_recursion::async_recursion;
 use async_trait::async_trait;
 
 use futures::{Stream, StreamExt};
+use kapi::FileUSize;
 use smallvec::SmallVec;
 use snafu::{ensure, OptionExt, ResultExt};
 
@@ -34,8 +35,30 @@ struct FatFile {
 
 #[async_trait]
 impl File for FatFile {
-    fn len(&self) -> u64 {
-        self.file_size as u64
+    fn len(&self) -> FileUSize {
+        self.file_size as FileUSize
+    }
+
+    /// Read bytes starting from `src_offset` in the file into the buffers in `destinations`.
+    /// The total length of `destinations` must fit within the file or the read will fail with an OutOfBounds error.
+    /// No IO will occur in this case.
+    async fn read<'v, 'dest>(
+        &self,
+        src_offset: FileUSize,
+        destinations: &'v [&'dest mut [u8]],
+    ) -> Result<(), Error> {
+        todo!()
+    }
+
+    /// Write bytes starting at `dst_offset` in the file from the buffers in `sources`.
+    /// The total length of `sources` must fit within the file or the write will fail with an OutOfBounds error.
+    /// No IO will occur in this case.
+    async fn write<'v, 'src>(
+        &mut self,
+        dst_offset: FileUSize,
+        sources: &'v [&'src [u8]],
+    ) -> Result<(), Error> {
+        todo!()
     }
 
     async fn load_pages(
@@ -111,15 +134,6 @@ impl File for FatFile {
         }
 
         Ok(())
-    }
-
-    async fn flush_pages(
-        &mut self,
-        _dest_offset: u64,
-        _src_address: PhysicalAddress,
-        _num_pages: usize,
-    ) -> Result<(), Error> {
-        todo!();
     }
 }
 
@@ -411,13 +425,6 @@ impl Handler {
 
 #[async_trait]
 impl RegistryHandler for Handler {
-    async fn open_block_store(&self, _subpath: &Path) -> Result<Box<dyn BlockStore>, Error> {
-        Err(Error::Registry {
-            reason: "".into(),
-            source: Box::new(RegistryError::Unsupported),
-        })
-    }
-
     async fn open_file(&self, subpath: &Path) -> Result<Box<dyn super::File>, Error> {
         log::trace!("attempting to locate {subpath} in FAT volume");
 

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -1,6 +1,7 @@
 //! File system drivers.
 use alloc::boxed::Box;
 use async_trait::async_trait;
+use kapi::FileUSize;
 use snafu::Snafu;
 
 use crate::{error::Error, memory::PhysicalAddress};
@@ -19,11 +20,11 @@ pub enum FsError {
     },
 }
 
-/// A File is a mappable persistent data blob
+/// A File is a persistent blob of bytes.
 #[async_trait]
-pub trait File {
+pub trait File: Send {
     /// Returns the length of the store in bytes.
-    fn len(&self) -> u64;
+    fn len(&self) -> FileUSize;
 
     fn is_empty(&self) -> bool {
         self.len() == 0
@@ -32,7 +33,7 @@ pub trait File {
     /// Read `num_pages` pages starting at `src_offset` (in bytes) from the file into `dest_address` in memory
     async fn load_pages(
         &mut self,
-        src_offset: u64,
+        src_offset: FileUSize,
         dest_address: PhysicalAddress,
         num_pages: usize,
     ) -> Result<(), Error>;
@@ -40,7 +41,7 @@ pub trait File {
     /// Write any changes from the in-memory file contents at `src_address` back to the persistent store
     async fn flush_pages(
         &mut self,
-        dest_offset: u64,
+        dest_offset: FileUSize,
         src_address: PhysicalAddress,
         num_pages: usize,
     ) -> Result<(), Error>;

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -26,23 +26,34 @@ pub trait File: Send {
     /// Returns the length of the store in bytes.
     fn len(&self) -> FileUSize;
 
+    /// Returns true if the file is empty.
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Read bytes starting from `src_offset` in the file into the buffers in `destinations`.
+    /// The total length of `destinations` must fit within the file or the read will fail with an OutOfBounds error.
+    /// No IO will occur in this case.
+    async fn read<'v, 'dest>(
+        &self,
+        src_offset: FileUSize,
+        destinations: &'v [&'dest mut [u8]],
+    ) -> Result<(), Error>;
+
+    /// Write bytes starting at `dst_offset` in the file from the buffers in `sources`.
+    /// The total length of `sources` must fit within the file or the write will fail with an OutOfBounds error.
+    /// No IO will occur in this case.
+    async fn write<'v, 'src>(
+        &mut self,
+        dst_offset: FileUSize,
+        sources: &'v [&'src [u8]],
+    ) -> Result<(), Error>;
 
     /// Read `num_pages` pages starting at `src_offset` (in bytes) from the file into `dest_address` in memory
     async fn load_pages(
         &mut self,
         src_offset: FileUSize,
         dest_address: PhysicalAddress,
-        num_pages: usize,
-    ) -> Result<(), Error>;
-
-    /// Write any changes from the in-memory file contents at `src_address` back to the persistent store
-    async fn flush_pages(
-        &mut self,
-        dest_offset: FileUSize,
-        src_address: PhysicalAddress,
         num_pages: usize,
     ) -> Result<(), Error>;
 }

--- a/kernel/src/memory/mod.rs
+++ b/kernel/src/memory/mod.rs
@@ -2,8 +2,7 @@
 //!
 //! There are three allocators:
 //! - Physical memory allocator (for physical pages of RAM)
-//! - Virtual memory allocator (for virtual pages of addresses that are unmapped, in the kernel
-//! address space)
+//! - Virtual memory allocator (for virtual pages of addresses that are unmapped, in the kernel address space)
 //! - The kernel heap, for Rust heap allocations in the kernel
 //!
 //! Most things that need virtual addresses assigned (like device drivers) should use the global

--- a/kernel/src/memory/mod.rs
+++ b/kernel/src/memory/mod.rs
@@ -105,9 +105,15 @@ impl VirtualAddress {
         let lv1_index = ((0x1ff << 30) & self.0) >> 30;
         let lv2_index = ((0x1ff << 21) & self.0) >> 21;
         let lv3_index = ((0x1ff << 12) & self.0) >> 12;
-        let page_offset = self.0 & 0xfff;
+        let page_offset = self.page_offset();
 
         (tag, lv0_index, lv1_index, lv2_index, lv3_index, page_offset)
+    }
+
+    /// Offset in bytes from the beginning of the page this address is located in.
+    #[inline]
+    pub fn page_offset(&self) -> usize {
+        self.0 & 0xfff
     }
 
     /// Reconstitute a virtual address from the page table indices and page offset.

--- a/kernel/src/memory/paging.rs
+++ b/kernel/src/memory/paging.rs
@@ -3,6 +3,7 @@
 use core::{cell::OnceCell, ops::Range, ptr::NonNull, sync::atomic::AtomicBool};
 
 use bitfield::bitfield;
+use itertools::Itertools;
 use smallvec::SmallVec;
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
 use spin::Mutex;
@@ -183,6 +184,11 @@ pub enum MapError {
         virt_start: VirtualAddress,
     },
     InvalidTag,
+    #[snafu(display("Mapping expected at {address}: {reason}"))]
+    ExpectedMapping {
+        reason: &'static str,
+        address: VirtualAddress,
+    },
     #[snafu(display("Copy from unmapped region. last valid address={last_valid:?}, {remaining_bytes} bytes remaining in copy"))]
     CopyFromUnmapped {
         last_valid: Option<VirtualAddress>,
@@ -579,7 +585,7 @@ impl PageTable {
             return InvalidTagSnafu.fail().context(MapSnafu);
         }
 
-        let mut i = PageTableIter::starting_at(self, [i0, i1, i2, i3]);
+        let mut i = PageTableIter::starting_at_unchecked(self, [i0, i1, i2, i3]);
 
         let first = i
             .next()
@@ -655,14 +661,61 @@ impl PageTable {
         PageTableIter::new(self)
     }
 
+    /// Iterate over "raw slices" of a continuous virtual range in the table, translated to canonical addreses.
     pub fn iter_canonical_raw_bytes(
         &self,
         start_addr: VirtualAddress,
         size_in_bytes: usize,
-    ) -> Result<impl Iterator<Item = (*mut u8, usize)>, MemoryError> {
-        todo!()
+    ) -> Result<impl Iterator<Item = (*mut u8, usize)> + '_, MemoryError> {
+        // TODO: once we have this, we don't really need `mapped_copy_from` to be a seperate implementation
+        let end_addr = start_addr.add(size_in_bytes);
+        // the start of the next page after the end of the range
+        let end_page = VirtualAddress((end_addr.0 + PAGE_SIZE) & !(PAGE_SIZE - 1));
+        let mut bytes_so_far = 0;
+        // TODO: combine continuous slices to minimize the total number of slices returned.
+        // TODO: use itertools::coalesce
+        PageTableIter::starting_from_address(self, start_addr).map(|i| {
+            i.take_while(move |r| r.base_virt_addr < end_page)
+                .map(move |r| {
+                    let region_len = r.page_count * PAGE_SIZE;
+                    let (offset, len) = if bytes_so_far == 0 {
+                        (
+                            start_addr.page_offset(),
+                            (region_len - start_addr.page_offset()).min(size_in_bytes),
+                        )
+                    } else {
+                        (0, region_len.min(size_in_bytes - bytes_so_far))
+                    };
+                    bytes_so_far += len;
+                    unsafe {
+                        (
+                            r.base_phys_addr
+                                .to_virtual_canonical()
+                                .add(offset)
+                                .as_ptr::<u8>(),
+                            len,
+                        )
+                    }
+                })
+                .coalesce(|previous, current| {
+                    if unsafe { previous.0.add(previous.1) } == current.0 {
+                        Ok((previous.0, previous.1 + current.1))
+                    } else {
+                        Err((previous, current))
+                    }
+                })
+        })
     }
 
+    /// Iterate over slices into memory of a continuous virtual range in the table.
+    /// It is possible that the iterator does not extend to the entire length `size_in_bytes` but
+    /// in fact stops before then because less than `size_in_bytes` memory is mapped at that
+    /// address!
+    ///
+    /// # Safety
+    /// The caller must ensure that the pointers/lengths that would be returned from
+    /// [Self::iter_canonical_raw_bytes] are valid slices, or in other words that the memory that
+    /// these pages map really is memory you can access as a byte slice.
     pub unsafe fn iter_canonical_slices(
         &self,
         start_addr: VirtualAddress,
@@ -672,6 +725,15 @@ impl PageTable {
             .map(|i| i.map(|(p, s)| core::slice::from_raw_parts(p, s)))
     }
 
+    /// Iterate over mutable slices into memory of a continuous virtual range in the table.
+    /// It is possible that the iterator does not extend to the entire length `size_in_bytes` but
+    /// in fact stops before then because less than `size_in_bytes` memory is mapped at that
+    /// address!
+    ///
+    /// # Safety
+    /// The caller must ensure that the pointers/lengths that would be returned from
+    /// [Self::iter_canonical_raw_bytes] are valid slices, or in other words that the memory that
+    /// these pages map really is memory you can access as a byte slice.
     pub unsafe fn iter_canonical_slices_mut(
         &self,
         start_addr: VirtualAddress,
@@ -721,10 +783,43 @@ pub struct PageTableIter<'a> {
 
 impl<'a> PageTableIter<'a> {
     fn new(pt: &'a PageTable) -> Self {
-        Self::starting_at(pt, [0, 0, 0, 0])
+        Self::starting_at_unchecked(pt, [0, 0, 0, 0])
     }
 
-    fn starting_at(pt: &'a PageTable, indices: [usize; 4]) -> Self {
+    /// Starts an iterator at the mapping for some virtual address. If the first valid mapped
+    /// region discovered does not map the input address, an error is returned. There is no
+    /// guarantee that the subsequent mapped ranges will be continuous.
+    fn starting_from_address(pt: &'a PageTable, addr: VirtualAddress) -> Result<Self, MemoryError> {
+        let (tag, i0, i1, i2, i3, po) = addr.to_parts();
+
+        if !matches!((pt.high_addresses, tag), (true, 0xffff) | (false, 0x0)) {
+            return InvalidTagSnafu.fail().context(MapSnafu);
+        }
+
+        let mut i = PageTableIter::starting_at_unchecked(pt, [i0, i1, i2, i3]);
+        i.move_to_next_valid_map_entry();
+
+        let first = i
+            .current_entry()
+            .context(ExpectedMappingSnafu {
+                reason: "starting mapped region iterator at address",
+                address: addr,
+            })
+            .context(MapSnafu)?;
+
+        if i.current_va_from_stack().add(po) != addr {
+            Err(MemoryError::Map {
+                source: MapError::ExpectedMapping {
+                    reason: "starting_from_address: first region mapped after address does not map address",
+                    address: addr
+                }
+            })
+        } else {
+            Ok(i)
+        }
+    }
+
+    fn starting_at_unchecked(pt: &'a PageTable, indices: [usize; 4]) -> Self {
         let interrupt_guard = InterruptGuard::disable_interrupts_until_drop();
         let table_lock_guard = pt.level0_table.lock();
         let mut s = PageTableIter {

--- a/kernel/src/memory/paging.rs
+++ b/kernel/src/memory/paging.rs
@@ -654,6 +654,32 @@ impl PageTable {
     pub fn iter(&self) -> PageTableIter {
         PageTableIter::new(self)
     }
+
+    pub fn iter_canonical_raw_bytes(
+        &self,
+        start_addr: VirtualAddress,
+        size_in_bytes: usize,
+    ) -> Result<impl Iterator<Item = (*mut u8, usize)>, MemoryError> {
+        todo!()
+    }
+
+    pub unsafe fn iter_canonical_slices(
+        &self,
+        start_addr: VirtualAddress,
+        size_in_bytes: usize,
+    ) -> Result<impl Iterator<Item = &[u8]>, MemoryError> {
+        self.iter_canonical_raw_bytes(start_addr, size_in_bytes)
+            .map(|i| i.map(|(p, s)| core::slice::from_raw_parts(p, s)))
+    }
+
+    pub unsafe fn iter_canonical_slices_mut(
+        &self,
+        start_addr: VirtualAddress,
+        size_in_bytes: usize,
+    ) -> Result<impl Iterator<Item = &mut [u8]>, MemoryError> {
+        self.iter_canonical_raw_bytes(start_addr, size_in_bytes)
+            .map(|i| i.map(|(p, s)| core::slice::from_raw_parts_mut(p, s)))
+    }
 }
 
 impl Drop for PageTable {

--- a/kernel/src/memory/physical_buffer.rs
+++ b/kernel/src/memory/physical_buffer.rs
@@ -90,6 +90,19 @@ impl PhysicalBuffer {
     pub fn as_bytes_mut(&mut self) -> &mut [u8] {
         unsafe { core::slice::from_raw_parts_mut(self.vir_addr.as_ptr::<u8>(), self.len()) }
     }
+
+    /// Unsafely create a mutable reference to the bytes in the buffer even if the buffer is
+    /// shared or otherwise held by a immutable reference.
+    ///
+    /// # Safety
+    /// This is only safe if the caller has some way to make sure that mutating the buffer while
+    /// shared is safe (i.e. a lock)
+    // Clippy is justfied in complaining about this function, but at least this way it is obvious
+    // when it happens instead of the caller doing it themselves.
+    #[allow(clippy::mut_from_ref)]
+    pub unsafe fn as_bytes_mut_force_unsafe(&self) -> &mut [u8] {
+        core::slice::from_raw_parts_mut(self.vir_addr.as_ptr::<u8>(), self.len())
+    }
 }
 
 impl Drop for PhysicalBuffer {

--- a/kernel/src/process/commands.rs
+++ b/kernel/src/process/commands.rs
@@ -343,7 +343,7 @@ impl Process {
                 code: Some(ErrorCode::OutOfBounds)
             }
         );
-        let destinations = unsafe {
+        let mut destinations = unsafe {
             self.page_tables
                 .iter_canonical_slices_mut(info.dst_buffer.data.into(), info.dst_buffer.len)
                 .context(MemorySnafu {
@@ -351,7 +351,7 @@ impl Process {
                 })?
                 .collect::<SmallVec<[&mut [u8]; 8]>>()
         };
-        file.read(info.src_offset, &destinations)
+        file.read(info.src_offset, &mut destinations)
             .await
             .map(|()| cmpl::Success)
     }

--- a/kernel/src/process/commands.rs
+++ b/kernel/src/process/commands.rs
@@ -6,17 +6,36 @@ use futures::FutureExt;
 use kapi::{
     commands::{self as cmds, Kind as CmdKind},
     completions::{self as cmpl, ErrorCode, Kind as CmplKind},
-    PATH_MAX_LEN,
 };
 use snafu::ensure;
 
 use crate::{
-    error::{self, Error, InnerSnafu, MemorySnafu},
+    error::{self, Error, InnerSnafu, MemorySnafu, Utf8Snafu},
     process::*,
-    registry::Path,
+    registry::{registry, PathBuf},
 };
 
 use self::memory::paging::kernel_table;
+
+macro_rules! command_dispatch {
+    {
+        $kind:expr,
+        $(
+            $cmd:pat => $res:expr
+        ),*
+    } => {
+        match $kind {
+            $($cmd => $res.map(Into::into),)*
+            kind => Err(Error::Misc {
+                reason: alloc::format!(
+                            "received unknown command: {:?}",
+                            core::mem::discriminant(kind)
+                        ),
+                code: Some(ErrorCode::UnknownCommand),
+            }),
+        }
+    };
+}
 
 /// Implementation of user-space commands.
 impl Process {
@@ -193,6 +212,19 @@ impl Process {
         Ok(thread.exit_code().await)
     }
 
+    /// Read a path from user-space into the kernel.
+    fn read_user_path(&self, path: &kapi::Path) -> Result<PathBuf, Error> {
+        let mut path_buf = alloc::vec![0; path.len];
+        self.page_tables
+            .mapped_copy_from(path.text.into(), &mut path_buf)
+            .context(error::MemorySnafu {
+                reason: "invalid path slice",
+            })?;
+        PathBuf::from_bytes(path_buf).with_context(|_| Utf8Snafu {
+            reason: alloc::format!("user path: {:?}", path),
+        })
+    }
+
     async fn spawn_child(
         self: &Arc<Process>,
         info: &cmds::SpawnProcess,
@@ -200,17 +232,7 @@ impl Process {
         recv_qu: Weak<UserQueue<Completion>>,
     ) -> Result<cmpl::NewProcess, Error> {
         // convert info.binary_path into a kernel Path
-        let mut path_buf = [0u8; PATH_MAX_LEN];
-        self.page_tables
-            .mapped_copy_from(
-                info.binary_path.text.into(),
-                &mut path_buf[0..info.binary_path.len],
-            )
-            .context(error::MemorySnafu {
-                reason: "invalid path slice",
-            })?;
-        let binary_path = Path::from_bytes(&path_buf[0..info.binary_path.len])
-            .context(error::Utf8Snafu { reason: "path" })?;
+        let binary_path = self.read_user_path(&info.binary_path)?;
 
         let params_buf = (info.parameters.len > 0)
             .then(|| {
@@ -269,43 +291,61 @@ impl Process {
         Ok(proc.exit_code().await)
     }
 
+    async fn open_file(
+        self: &Arc<Process>,
+        info: &cmds::OpenFile,
+    ) -> Result<cmpl::OpenedFileHandle, Error> {
+        let path = self.read_user_path(&info.path)?;
+        let handle = FileHandle::new(
+            self.next_handle
+                .fetch_add(1, core::sync::atomic::Ordering::AcqRel),
+        )
+        .expect("process next_handle counter contains valid handle");
+        let file = registry().open_file(&path).await?;
+        let size = file.len();
+        self.open_files.push(Arc::new(OpenFile {
+            handle,
+            file: crate::tasks::locks::Mutex::new(file),
+        }));
+        Ok(cmpl::OpenedFileHandle { handle, size })
+    }
+
+    async fn close_file(
+        self: &Arc<Process>,
+        info: &cmds::CloseFile,
+    ) -> Result<cmpl::Success, Error> {
+        if self.open_files.remove(|f| f.handle == info.handle) {
+            Ok(cmpl::Success)
+        } else {
+            Err(Error::Misc {
+                reason: "close on unknown handle".into(),
+                code: Some(ErrorCode::InvalidId),
+            })
+        }
+    }
+
     /// Execute a single command on the process, returning the resulting completion.
     pub async fn dispatch_command(
         self: &Arc<Process>,
         cmd: Command,
         recv_qu: Weak<UserQueue<Completion>>,
     ) -> Completion {
-        let res = match &cmd.kind {
+        let res = command_dispatch! {
+            &cmd.kind,
             CmdKind::Test(cmds::Test { arg }) => Ok(cmpl::Test {
                 arg: *arg,
                 pid: self.id,
-            }
-            .into()),
-            CmdKind::CreateCompletionQueue(info) => {
-                self.create_completion_queue(info).await.map(Into::into)
-            }
-            CmdKind::CreateSubmissionQueue(info) => {
-                self.create_submission_queue(info).await.map(Into::into)
-            }
-            CmdKind::DestroyQueue(info) => self.destroy_queue(info).map(Into::into),
-            CmdKind::SpawnThread(info) => self
-                .spawn_thread(info, cmd.id, recv_qu)
-                .await
-                .map(Into::into),
-            CmdKind::WatchThread(info) => self.watch_thread(info).await.map(Into::into),
-            CmdKind::SpawnProcess(info) => self
-                .spawn_child(info, cmd.id, recv_qu)
-                .await
-                .map(Into::into),
-            CmdKind::WatchProcess(info) => self.watch_process(info).await.map(Into::into),
-            CmdKind::KillProcess(info) => kill_process(info).await.map(Into::into),
-            kind => Err(Error::Misc {
-                reason: alloc::format!(
-                    "received unknown command: {:?}",
-                    core::mem::discriminant(kind)
-                ),
-                code: Some(ErrorCode::UnknownCommand),
             }),
+            CmdKind::CreateCompletionQueue(info) => self.create_completion_queue(info).await,
+            CmdKind::CreateSubmissionQueue(info) => self.create_submission_queue(info).await,
+            CmdKind::DestroyQueue(info) => self.destroy_queue(info),
+            CmdKind::SpawnThread(info) => self.spawn_thread(info, cmd.id, recv_qu).await,
+            CmdKind::WatchThread(info) => self.watch_thread(info).await,
+            CmdKind::SpawnProcess(info) => self.spawn_child(info, cmd.id, recv_qu).await,
+            CmdKind::WatchProcess(info) => self.watch_process(info).await,
+            CmdKind::KillProcess(info) => kill_process(info).await,
+            CmdKind::OpenFile(info) => self.open_file(info).await,
+            CmdKind::CloseFile(info) => self.close_file(info).await
         };
 
         let kind = res.unwrap_or_else(|e| {

--- a/kernel/src/process/spawn.rs
+++ b/kernel/src/process/spawn.rs
@@ -85,7 +85,8 @@ pub async fn spawn_process(
         .context(error::MemorySnafu {
             reason: "allocate temporary buffer for binary",
         })?;
-    f.read(0, &[src_data.as_bytes_mut()]).await?;
+    f.read(0, &mut [&mut src_data.as_bytes_mut()[0..f_len]])
+        .await?;
 
     // parse ELF binary
     let bin: elf::ElfBytes<elf::endian::LittleEndian> =

--- a/kernel/src/process/spawn.rs
+++ b/kernel/src/process/spawn.rs
@@ -160,11 +160,13 @@ pub async fn spawn_process(
         id: pid,
         page_tables: pt,
         threads: Default::default(),
-        next_queue_id: AtomicU16::new(FIRST_RECV_QUEUE_ID.into()), //AtomicU16::new((FIRST_RECV_QUEUE_ID.saturating_add(1)).into()),
+        next_queue_id: AtomicU16::new(FIRST_RECV_QUEUE_ID.into()),
         send_queues: Default::default(),
         recv_queues: Default::default(),
         address_space_allocator: Mutex::new(address_space_allocator),
         exit_state: Default::default(),
+        next_handle: AtomicU32::new(1),
+        open_files: Default::default(),
     });
     processes().push(proc.clone());
 

--- a/kernel/src/registry/mod.rs
+++ b/kernel/src/registry/mod.rs
@@ -43,11 +43,24 @@ pub enum ResourceType {
 
 /// A RegistryHandler responds to requests to open registered resources by path.
 #[async_trait]
-pub trait RegistryHandler {
+pub trait RegistryHandler: Sync {
     /// Open a [BlockStore][crate::storage::BlockStore] resource at `subpath`.
-    async fn open_block_store(&self, subpath: &Path) -> Result<Box<dyn BlockStore>, Error>;
+    async fn open_block_store(&self, subpath: &Path) -> Result<Box<dyn BlockStore>, Error> {
+        Err(Error::Registry {
+            reason: alloc::format!(
+                "subregistry for \"{subpath}\" does not support opening block stores"
+            ),
+            source: Box::new(RegistryError::Unsupported),
+        })
+    }
+
     /// Open a [File][crate::fs::File] resource at `subpath`.
-    async fn open_file(&self, subpath: &Path) -> Result<Box<dyn File>, Error>;
+    async fn open_file(&self, subpath: &Path) -> Result<Box<dyn File>, Error> {
+        Err(Error::Registry {
+            reason: alloc::format!("subregistry for \"{subpath}\" does not support opening files"),
+            source: Box::new(RegistryError::Unsupported),
+        })
+    }
 }
 
 // TODO: storing these as strings is bad as short strings might take up an unexpectedly large

--- a/kernel/src/registry/path.rs
+++ b/kernel/src/registry/path.rs
@@ -174,6 +174,14 @@ pub struct PathBuf {
     s: String,
 }
 
+impl PathBuf {
+    pub fn from_bytes(b: alloc::vec::Vec<u8>) -> Result<Self, core::str::Utf8Error> {
+        Ok(PathBuf {
+            s: String::from_utf8(b).map_err(|e| e.utf8_error())?,
+        })
+    }
+}
+
 impl<S: AsRef<str>> From<S> for PathBuf {
     fn from(value: S) -> Self {
         PathBuf {
@@ -199,6 +207,12 @@ impl Deref for PathBuf {
 
     fn deref(&self) -> &Self::Target {
         self.borrow()
+    }
+}
+
+impl AsRef<Path> for PathBuf {
+    fn as_ref(&self) -> &Path {
+        Path::new(&self.s)
     }
 }
 

--- a/kernel/src/storage/block_cache.rs
+++ b/kernel/src/storage/block_cache.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::error;
 use crate::memory::{PhysicalBuffer, PAGE_SIZE};
-use crate::tasks::locks::{Mutex, RwLock};
+use crate::tasks::locks::Mutex;
 use alloc::vec::Vec;
 
 use bitfield::{bitfield, BitRange};
@@ -50,8 +50,9 @@ pub struct BlockCache {
     chunk_size: usize,
     blocks_per_chunk: usize,
     num_chunks: usize,
-    metadata: Vec<RwLock<ChunkMetadata>>,
-    buffer: RwLock<PhysicalBuffer>,
+    metadata: Vec<Mutex<ChunkMetadata>>,
+    /// The actual buffer used for caching. This is synchronized per-chunk via the `metadata` locks.
+    buffer: PhysicalBuffer,
     buffer_pa: PhysicalAddress,
 }
 
@@ -98,7 +99,7 @@ impl BlockCache {
             buffer_pa: buffer.physical_address(),
             // TODO: in the future, the physical memory allocator should support loaning pages to
             // caches etc but for now we just allocate the entire cache upfront
-            buffer: RwLock::new(buffer),
+            buffer,
         })
     }
 
@@ -150,13 +151,25 @@ impl BlockCache {
             .offset((chunk_id * self.chunk_size as u64) as isize)
     }
 
-    async fn load_chunk(
+    /// Update a single cache chunk to ensure that it holds data from a block at `compose_address(tag, chunk_id)` and copy some memory while the chunk is locked.
+    ///
+    /// The chunk in the cache for `chunk_id` will be replaced with the contents of the block at
+    /// `compose_address(tag, chunk_id)`.
+    /// If the chunk is dirty, it will be written to storage before being replaced.
+    /// The chunk metadata is written to record the new tag, occupation and dirtiness if it has changed.
+    /// Bytes from the `src` will be copied to the `dst` (both buffers must have the same length),
+    /// regardless if any IO has taken place. The bytes are copied while the lock on the chunk is
+    /// held, so it is guarenteed that the memory for the chunk in the cache buffer will contain
+    /// the bytes of the block referred to by `compose_address(tag, chunk_id)`.
+    async fn update_single_chunk(
         &self,
         tag: u64,
         chunk_id: u64,
         mark_dirty: bool,
+        src: &[u8],
+        dst: &mut [u8],
     ) -> Result<(), StorageError> {
-        let mut md = self.metadata[chunk_id as usize].write().await;
+        let mut md = self.metadata[chunk_id as usize].lock().await;
         if !md.occupied() || md.tag() != tag {
             // chunk is not present
             log::trace!("loading chunk {tag}:{chunk_id}, md={:?}", *md);
@@ -169,7 +182,6 @@ impl BlockCache {
                     )
                     .await?;
             }
-            // because the cache has 1 page = 1 chunk, it only ever accesses one page at a time
             store
                 .read_blocks(
                     self.compose_address(tag, chunk_id),
@@ -180,25 +192,52 @@ impl BlockCache {
             md.set_occupied(true);
             md.set_dirty(mark_dirty);
         }
+        // do the actual copy - it's important to make sure the metadata stays locked for this so
+        // that another thread doesn't decide to repurpose this chunk while we are copying.
+        dst.copy_from_slice(src);
         Ok(())
     }
 
-    async fn load_chunks(
+    /// Process `num_chunks_inclusive` chunks in the cache starting at `(starting_tag, starting_chunk_id)` in parallel using [Self::process_single_chunk].
+    /// If `num_chunks_inclusive` is greater than [Self::num_chunks], then the tag will wrap.
+    ///
+    /// The `src` and `dst` will be divided into chunks of [Self::chunk_size] bytes.
+    /// To work correctly, they must be chunk-aligned if they are slices into the cache buffer.
+    /// An offset `initial_offset` can be applied to the first chunk to account for skipping some number of blocks/bytes. For reads, this will be the `src` buffer, and for writes it will be the `dst` buffer.
+    async fn process_chunks(
         &self,
-        starting_tag: u64,
-        starting_chunk_id: u64,
+        (starting_tag, starting_chunk_id): (u64, u64),
         num_chunks_inclusive: u64,
-        mark_dirty: bool,
+        is_write: bool,
+        src: &[u8],
+        dst: &mut [u8],
+        initial_offset: usize,
     ) -> Result<(), StorageError> {
-        future::try_join_all((0..num_chunks_inclusive).map(|i| {
-            let mut tag = starting_tag;
-            let mut chunk_id = starting_chunk_id + i;
-            if chunk_id >= self.num_chunks as u64 {
-                tag += chunk_id / self.num_chunks as u64;
-                chunk_id %= self.num_chunks as u64;
-            }
-            self.load_chunk(tag, chunk_id, mark_dirty)
-        }))
+        future::try_join_all(
+            (0..num_chunks_inclusive)
+                .zip(src.chunks(self.chunk_size))
+                .zip(dst.chunks_mut(self.chunk_size))
+                .map(|((i, src), dst)| {
+                    let mut tag = starting_tag;
+                    let mut chunk_id = starting_chunk_id + i;
+                    if chunk_id >= self.num_chunks as u64 {
+                        tag += chunk_id / self.num_chunks as u64;
+                        chunk_id %= self.num_chunks as u64;
+                    }
+                    let len = if is_write { src.len() } else { dst.len() };
+                    let src = if !is_write && i == 0 {
+                        &src[initial_offset..(initial_offset + len)]
+                    } else {
+                        &src[0..len]
+                    };
+                    let dst = if is_write && i == 0 {
+                        &mut dst[initial_offset..(initial_offset + len)]
+                    } else {
+                        &mut dst[0..len]
+                    };
+                    self.update_single_chunk(tag, chunk_id, is_write, src, dst)
+                }),
+        )
         .await
         .map(|_| ()) //throw away the silly vector of units TODO: can we not collect the units?
     }
@@ -208,46 +247,40 @@ impl BlockCache {
         &self,
         mut address: BlockAddress,
         mut byte_offset: usize,
-        dest: &mut [u8],
+        dst: &mut [u8],
     ) -> Result<(), StorageError> {
         if byte_offset >= self.block_size() {
             address.0 += (byte_offset / self.block_size()) as u64;
             byte_offset %= self.block_size();
         }
 
-        let (starting_tag, starting_chunk_id, initial_block_offset) =
-            self.decompose_address(address);
+        let (mut tag, mut chunk_id, mut block_offset) = self.decompose_address(address);
 
-        let num_chunks_inclusive = dest.len().div_ceil(self.chunk_size);
+        let mut num_chunks_inclusive = dst.len().div_ceil(self.chunk_size);
         // log::trace!("copying from {starting_tag}:{starting_chunk_id}:{initial_block_offset} + {byte_offset} len={},chunk count={} [{address}]", dest.len(), num_chunks_inclusive);
-        if num_chunks_inclusive > self.num_chunks {
-            // if the read is larger than the entire cache
-            // TODO: implement reads larger than the size of the cache by directly issuing a read
-            // that writes to the destination buffer
-            todo!("implement large reads");
+        while num_chunks_inclusive > 0 {
+            // we can process in a single call at most the number of chunks between where we start in the cache buffer and the end of the buffer
+            let batch_num_chunks = num_chunks_inclusive.min(self.num_chunks - chunk_id as usize);
+
+            self.process_chunks(
+                (tag, chunk_id),
+                batch_num_chunks as u64,
+                false,
+                &self.buffer.as_bytes()[chunk_id as usize * self.chunk_size..],
+                dst,
+                block_offset as usize * self.block_size + byte_offset,
+            )
+            .await?;
+
+            num_chunks_inclusive -= batch_num_chunks;
+            chunk_id += batch_num_chunks as u64;
+            if chunk_id >= self.num_chunks as u64 {
+                tag += chunk_id / self.num_chunks as u64;
+                chunk_id %= self.num_chunks as u64;
+            }
+            block_offset = 0;
         }
-        self.load_chunks(
-            starting_tag,
-            starting_chunk_id,
-            num_chunks_inclusive as u64,
-            false,
-        )
-        .await?;
-        let offset = starting_chunk_id as usize * self.chunk_size
-            + initial_block_offset as usize * self.block_size
-            + byte_offset;
-        let cache = self.buffer.read().await;
-        if offset + dest.len() > cache.len() {
-            let split = (offset + dest.len()) - cache.len();
-            log::trace!(
-                "offset = {offset}, dest.len()={}, split={split}",
-                dest.len()
-            );
-            dest[0..split].copy_from_slice(&cache.as_bytes()[offset..]);
-            dest[split..].copy_from_slice(&cache.as_bytes()[0..split]);
-        } else {
-            dest.copy_from_slice(&cache.as_bytes()[offset..offset + dest.len()]);
-        }
+
         Ok(())
     }
 
@@ -263,38 +296,39 @@ impl BlockCache {
             byte_offset %= self.block_size();
         }
 
-        let (starting_tag, starting_chunk_id, initial_block_offset) =
-            self.decompose_address(address);
-        log::trace!("writing to {starting_tag}:{starting_chunk_id}:{initial_block_offset}");
-        let num_chunks_inclusive = src.len().div_ceil(self.chunk_size);
-        if num_chunks_inclusive > self.num_chunks {
-            // if the write is larger than the entire cache
-            // TODO: implement writes larger than the size of the cache by writing the ends using
-            // the cache (to take care of offsets) and then issuing a big direct write for the rest
-            todo!("implement large writes");
-        }
-        self.load_chunks(
-            starting_tag,
-            starting_chunk_id,
-            num_chunks_inclusive as u64,
-            true,
-        )
-        .await?;
-        let offset = starting_chunk_id as usize * self.chunk_size
-            + initial_block_offset as usize * self.block_size
-            + byte_offset;
-        self.buffer.write().await.as_bytes_mut()[offset..offset + src.len()].copy_from_slice(src);
-        Ok(())
-    }
+        let (mut tag, mut chunk_id, mut block_offset) = self.decompose_address(address);
 
-    /// Update bytes in the cache in a certain range. All blocks in the range will be loaded into the cache if they are unloaded.
-    pub async fn update_bytes(
-        &self,
-        _address: BlockAddress,
-        _size_in_bytes: usize,
-        _f: impl FnOnce(&mut [u8]),
-    ) {
-        todo!()
+        let mut num_chunks_inclusive = src.len().div_ceil(self.chunk_size);
+        // log::trace!("copying from {starting_tag}:{starting_chunk_id}:{initial_block_offset} + {byte_offset} len={},chunk count={} [{address}]", dest.len(), num_chunks_inclusive);
+        while num_chunks_inclusive > 0 {
+            // we can process in a single call at most the number of chunks between where we start in the cache buffer and the end of the buffer
+            let batch_num_chunks = num_chunks_inclusive.min(self.num_chunks - chunk_id as usize);
+
+            let dst = unsafe {
+                // SAFETY: we use the chunk locks to synchronize shared access to the cache buffer, so this is fine.
+                &mut self.buffer.as_bytes_mut_force_unsafe()[chunk_id as usize * self.chunk_size..]
+            };
+
+            self.process_chunks(
+                (tag, chunk_id),
+                batch_num_chunks as u64,
+                true,
+                src,
+                dst,
+                block_offset as usize * self.block_size + byte_offset,
+            )
+            .await?;
+
+            num_chunks_inclusive -= batch_num_chunks;
+            chunk_id += batch_num_chunks as u64;
+            if chunk_id >= self.num_chunks as u64 {
+                tag += chunk_id / self.num_chunks as u64;
+                chunk_id %= self.num_chunks as u64;
+            }
+            block_offset = 0;
+        }
+
+        Ok(())
     }
 }
 
@@ -469,7 +503,7 @@ mod test {
         let c = BlockCache::new(bs, 1).unwrap();
         let mut buf = [0; 8];
         buf.copy_from_slice(b"testtest");
-        block_on(c.write_bytes(BlockAddress(7), 0, &buf));
+        block_on(c.write_bytes(BlockAddress(7), 0, &buf)).unwrap();
         assert_eq!(rc.swap(0, Ordering::Acquire), PAGE_SIZE / 8);
         assert_eq!(wc.load(Ordering::Acquire), 0); // no writes yet
         buf.fill(0);
@@ -486,7 +520,7 @@ mod test {
         let c = BlockCache::new(bs, 1).unwrap();
         let mut buf = [0; 8];
         buf.copy_from_slice(b"testtest");
-        block_on(c.write_bytes(BlockAddress(7), 0, &buf));
+        block_on(c.write_bytes(BlockAddress(7), 0, &buf)).unwrap();
         assert_eq!(rc.swap(0, Ordering::Acquire), PAGE_SIZE / 8);
         assert_eq!(wc.load(Ordering::Acquire), 0); // no writes yet
         buf.fill(0);

--- a/kernel/src/storage/nvme/block_store.rs
+++ b/kernel/src/storage/nvme/block_store.rs
@@ -41,7 +41,7 @@ impl BlockStore for NamespaceBlockStore {
                 }
                 .build()
             })?;
-        log::trace!("read blocks {source_addr}[..{total_num_blocks}] -> {destination_addrs:?}");
+        log::trace!("read blocks {source_addr}[0..{total_num_blocks}] -> {destination_addrs:?}");
         let cmp = self.io_cq.wait_for_completion(
             self.io_sq.begin()
                 .expect("NVMe submission queue full. TODO: we should be able to await for a new spot in the queue rather than panic")

--- a/kernel/src/storage/nvme/interrupt.rs
+++ b/kernel/src/storage/nvme/interrupt.rs
@@ -38,7 +38,7 @@ impl Future for CompletionFuture {
                 Poll::Pending
             }
             Some(Waiting(_)) => {
-                log::warn!("future repolled while waiting");
+                log::warn!("future repolled while waiting cmd id = {}", self.cmd_id);
                 self.pending_completions
                     .insert_blocking(self.cmd_id, Waiting(cx.waker().clone()));
                 Poll::Pending
@@ -106,7 +106,7 @@ fn handle_interrupt(
                     w.wake_by_ref();
                     Ready(cmp)
                 },
-                Ready(old_cmp) => panic!("recieved second completion {cmp:?} for id with pending ready completion {old_cmp:?}"),
+                Ready(old_cmp) => panic!("received second completion {cmp:?} for id with pending ready completion {old_cmp:?}"),
             }
         } else {
             // log::trace!("inserting ready completion before future was ever polled");

--- a/kernel/src/tasks/locks.rs
+++ b/kernel/src/tasks/locks.rs
@@ -282,6 +282,12 @@ impl<T> RwLock<T> {
     }
 }
 
+impl<T: Default> Default for RwLock<T> {
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
 impl<T: ?Sized> RwLock<T> {
     /// Lock for reading (shared but exclusive with writing). If the data is unavailable, this yields until it becomes available.
     pub async fn read(&self) -> RwLockReadGuard<T> {

--- a/kernel/src/tasks/mod.rs
+++ b/kernel/src/tasks/mod.rs
@@ -57,7 +57,7 @@ struct Executor {
 impl Default for Executor {
     fn default() -> Self {
         Self {
-            ready_queue: Arc::new(ArrayQueue::new(128)),
+            ready_queue: Arc::new(ArrayQueue::new(1024)),
             new_task_queue: Rc::new(ArrayQueue::new(32)),
             next_task_id: Arc::new(AtomicU32::new(1)),
         }


### PR DESCRIPTION
Makes progress on #7 and also implements these features in the FAT driver.

## Definition
- [x] Files
    - [x] Create
    - [x] Open
    - [x] Read
    - [x] Write
    - [x] Resize
    - [x] Close
    - [x] Delete

## Tests
- [x] Open/close file
- [x] Create, delete, close file
- [x] Fail to create file that already exists
- [x] Fail to open a file that does not exist
- [x] Open a file, read from it, close the file
- [x] Open a file, read from it partially, close the file
- [x] Create a file F, write to it, close the file.
- [x] Open F, read back contents, close the file.
- [x] Open F, attempt to read past the end, check, close the file.
- [x] Open F, attempt to write past the end, check for error, close the file.
- [ ] Open F, write to a part, close the file. Then open it again and read the part back.
- [x] Resize F smaller, check remaining part, close
- [x] Resize F larger, check remaining part, check end, close 
- [x] Delete the previous file.
- [x] Delete non-existent file.
- [x] Create a file, write to it, read back and check equal, close & delete.
- [x] Read, Write, Resize, Close an invalid non-zero file handle and check for errors


## Implementation
- [ ] Files
    - [ ] Create
    - [x] Open
    - [x] Read
    - [ ] Write
    - [ ] Resize
    - [x] Close
    - [ ] Delete

- [ ] Fixes/Refactors
    - [x] Rewrite the block cache to be correct and safe for concurrency
    - [ ] Port FAT directory entry code to new `cluster_address_stream` function 